### PR TITLE
t005: fix unused FIRST_RUN variable (ShellCheck SC2034)

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -7,10 +7,9 @@ echo "==> Starting NetBird for Cloudron"
 # PHASE 1: First-Run Detection
 # ============================================
 if [[ ! -f /app/data/.initialized ]]; then
-    FIRST_RUN=true
-    echo "==> First run detected"
+    echo "==> First run detected — will initialize config and secrets"
 else
-    FIRST_RUN=false
+    echo "==> Existing installation detected"
 fi
 
 # ============================================


### PR DESCRIPTION
## Summary

- Removes unused `FIRST_RUN` variable from `start.sh` that triggered ShellCheck SC2034 warning
- Replaces with descriptive log messages for both first-run and existing-installation paths
- ShellCheck now passes clean with zero warnings

Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated startup messages to provide clearer feedback during initial application setup and subsequent launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->