### PR TITLE
t006: Add nginx security headers and run nginx as non-root user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Added nginx security headers: `X-Frame-Options`, `X-Content-Type-Options`, `X-XSS-Protection`, `Referrer-Policy` to all responses.
+- nginx now runs as non-root user (`cloudron`) via supervisord, matching the netbird-server process.
+- Added explicit `scgi_temp_path` and `uwsgi_temp_path` directives to ensure all nginx temp paths are in the writable `/run/nginx/` directory.
+
 ## [2.0.0] - 2026-02-26
 
 ### Breaking Changes

--- a/start.sh
+++ b/start.sh
@@ -19,7 +19,7 @@ fi
 mkdir -p /app/data/config
 mkdir -p /app/data/netbird
 mkdir -p /app/data/dashboard
-mkdir -p /run/nginx/client_body /run/nginx/proxy /run/nginx/fastcgi
+mkdir -p /run/nginx/client_body /run/nginx/proxy /run/nginx/fastcgi /run/nginx/scgi /run/nginx/uwsgi
 mkdir -p /run/netbird
 
 # ============================================
@@ -191,6 +191,8 @@ http {
     client_body_temp_path /run/nginx/client_body;
     proxy_temp_path /run/nginx/proxy;
     fastcgi_temp_path /run/nginx/fastcgi;
+    scgi_temp_path /run/nginx/scgi;
+    uwsgi_temp_path /run/nginx/uwsgi;
 
     # Required for long-lived gRPC and WebSocket connections
     client_header_timeout 1d;
@@ -208,6 +210,12 @@ http {
     server {
         listen 8080 http2;
         server_name _;
+
+        # Security headers
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
         # Common proxy headers
         proxy_set_header X-Real-IP $remote_addr;

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -6,6 +6,7 @@ pidfile=/run/supervisord.pid
 
 [program:nginx]
 command=/usr/sbin/nginx -c /app/data/config/nginx.conf -g "daemon off;"
+user=cloudron
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
## Summary

- Add standard security headers (`X-Frame-Options`, `X-Content-Type-Options`, `X-XSS-Protection`, `Referrer-Policy`) to all nginx responses
- Run nginx as non-root `cloudron` user via supervisord `user=cloudron` directive (was running as root)
- Add explicit `scgi_temp_path` and `uwsgi_temp_path` directives and create corresponding directories to ensure all nginx temp paths are in the writable `/run/nginx/` directory

## Files Changed

| File | Change |
|------|--------|
| `start.sh` | Security headers in nginx config, scgi/uwsgi temp paths and dirs |
| `supervisord.conf` | `user=cloudron` for nginx program |
| `CHANGELOG.md` | Document security improvements under [Unreleased] |

## Design Decisions

- **No CSP header yet**: Content-Security-Policy requires careful tuning for the dashboard SPA (inline scripts, API origins, WebSocket connections). Adding a wrong CSP would break the dashboard. This should be a separate task with testing.
- **`always` flag on headers**: Ensures headers are sent on all response codes (including errors), not just 2xx/3xx.
- **Temp path belt-and-suspenders**: scgi/uwsgi modules aren't actively used, but explicitly setting their temp paths prevents any future issue if nginx defaults change.

## Testing

After `cloudron build && cloudron install`:
1. Verify nginx starts without errors in `cloudron logs`
2. Check response headers: `curl -I https://<domain>/` should show all 4 security headers
3. Verify dashboard loads correctly (security headers don't break SPA)
4. Verify gRPC and WebSocket connections still work

Closes #5