### PR TITLE
t008: Add error handling for openssl secret generation

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -64,14 +64,20 @@ mkdir -p /run/netbird
 
 # Encryption key for database-at-rest encryption
 if [[ ! -f /app/data/config/.encryption_key ]]; then
-    openssl rand -hex 16 >/app/data/config/.encryption_key
+    if ! openssl rand -hex 16 >/app/data/config/.encryption_key; then
+        echo "ERROR: Failed to generate encryption key" >&2
+        exit 1
+    fi
     chmod 600 /app/data/config/.encryption_key
 fi
 ENCRYPTION_KEY=$(cat /app/data/config/.encryption_key)
 
 # Auth secret for relay credential validation
 if [[ ! -f /app/data/config/.auth_secret ]]; then
-    openssl rand -hex 32 >/app/data/config/.auth_secret
+    if ! openssl rand -hex 32 >/app/data/config/.auth_secret; then
+        echo "ERROR: Failed to generate auth secret" >&2
+        exit 1
+    fi
     chmod 600 /app/data/config/.auth_secret
 fi
 AUTH_SECRET=$(cat /app/data/config/.auth_secret)


### PR DESCRIPTION
## Summary

- Wraps both `openssl rand` calls (encryption key and auth secret) in `if !` guards that `exit 1` on failure
- Prevents silent empty key file creation if `openssl` fails, which would leave NetBird running with no database encryption or relay auth

## Changes

**`start.sh`** (lines 66-82): Both secret generation blocks now check the `openssl rand` exit code and abort startup with a clear error message on failure.

## Testing

- ShellCheck passes clean
- No functional change to the happy path (openssl succeeds → same behavior as before)
- On openssl failure: startup aborts with `ERROR: Failed to generate encryption key` or `ERROR: Failed to generate auth secret` to stderr

Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error handling during initialization to detect and report failures immediately, preventing incomplete configuration and improving setup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->