### PR TITLE
fix: use -s instead of -f to detect empty secret files

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -62,7 +62,9 @@ mkdir -p /run/netbird
 # PHASE 3: Generate or Preserve Secrets
 # ============================================
 
-# Generate a hex secret file if it doesn't already exist.
+# Generate a hex secret file if it doesn't already exist and is non-empty.
+# Uses -s (exists AND non-empty) instead of -f (exists only) to handle the
+# case where a previous failed run left an empty file (PR #18 review).
 # On openssl failure, removes any partial/empty file to prevent the app
 # from starting with a blank secret on the next attempt (PR #12 review).
 generate_secret() {
@@ -70,7 +72,7 @@ generate_secret() {
     local key_length="$2"
     local key_name="$3"
 
-    if [[ -f "${file_path}" ]]; then
+    if [[ -s "${file_path}" ]]; then
         return 0
     fi
 


### PR DESCRIPTION
## Summary

- Changes `generate_secret()` in `start.sh` to use `[[ -s ]]` (exists AND non-empty) instead of `[[ -f ]]` (exists only), preventing the app from starting with a blank secret if a previous failed run left an empty file.

## Details

If a previous run crashed after creating the secret file but before `openssl rand` wrote to it, the old `-f` check would see the empty file and skip regeneration. The app would then start with an empty encryption key or auth secret, which is a security issue.

The `-s` test ensures the file both exists and has content before skipping generation.

## Source

Addresses review feedback from gemini-code-assist on PR #18 ([comment](https://github.com/marcusquinn/cloudron-netbird-app/pull/18#discussion_r2890392106)).

Closes #19