### PR TITLE
docs: document .auth_secret loss impact in persistent data warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ All persistent data is stored in `/app/data/` (Cloudron's `localstorage` addon) 
 | `/app/data/dashboard/` | Dashboard OIDC config (`config.json`, `.env`) |
 | `/app/data/.initialized` | First-run marker file |
 
-The encryption key encrypts setup keys and API tokens at rest in PostgreSQL. Both `.encryption_key` and `.auth_secret` are included in Cloudron backups. **Do not lose them** -- losing the encryption key means regenerating all setup keys and API tokens.
+The encryption key encrypts setup keys and API tokens at rest in PostgreSQL. Both `.encryption_key` and `.auth_secret` are included in Cloudron backups. **Do not lose them** -- losing the encryption key means regenerating all setup keys and API tokens, while losing the auth secret may disrupt relay server authentication.
 
 ## Development
 


### PR DESCRIPTION
## Summary

- Add missing documentation about the consequence of losing `.auth_secret` (relay server authentication disruption) to the persistent data warning in README.md
- The existing warning only described the impact of losing `.encryption_key` but omitted `.auth_secret`

**Source**: Gemini review feedback on PR #4 ([comment](https://github.com/marcusquinn/cloudron-netbird-app/pull/4#discussion_r2868466465))

Closes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that losing an authentication secret may disrupt relay server authentication, in addition to requiring regeneration of setup keys and API tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->