### PR TITLE
fix: update nginx security headers per PR #10 review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Added nginx security headers: `X-Frame-Options`, `X-Content-Type-Options`, `X-XSS-Protection`, `Referrer-Policy` to all responses.
+- Changed `X-XSS-Protection` from `1; mode=block` to `0` — the XSS auditor is deprecated and can introduce vulnerabilities in older browsers (PR #10 review).
+- Added `Permissions-Policy: interest-cohort=()` header to disable FLoC tracking (PR #10 review).
 - nginx now runs as non-root user (`cloudron`) via supervisord, matching the netbird-server process.
 - Added explicit `scgi_temp_path` and `uwsgi_temp_path` directives to ensure all nginx temp paths are in the writable `/run/nginx/` directory.
 

--- a/start.sh
+++ b/start.sh
@@ -265,8 +265,9 @@ http {
         # Security headers
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
-        add_header X-XSS-Protection "1; mode=block" always;
+        add_header X-XSS-Protection "0" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "interest-cohort=()" always;
 
         # Common proxy headers
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary

- Change `X-XSS-Protection` from `1; mode=block` to `0` -- the XSS auditor is deprecated and can introduce vulnerabilities in older browsers via timing attacks
- Add `Permissions-Policy: interest-cohort=()` header to disable FLoC tracking

Both changes align with current OWASP/MDN best practices for security headers.

**Source**: Gemini code review on PR #10 ([comment](https://github.com/marcusquinn/cloudron-netbird-app/pull/10#discussion_r2868676837))

Closes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Disabled deprecated XSS auditor protection header in favor of modern browser security mechanisms
  * Added privacy header to opt-out of federated learning audience tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->