### PR TITLE
t009: fix quality-debt in start.sh from PR #9 review feedback

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -19,18 +19,25 @@ validate_env() {
         "CLOUDRON_POSTGRESQL_DATABASE"
         "CLOUDRON_POSTGRESQL_PORT"
     )
-    local missing=0
+    local missing_vars=()
     local var
 
     for var in "${required_vars[@]}"; do
         if [[ -z "${!var:-}" ]]; then
-            echo "ERROR: Required environment variable ${var} is not set" >&2
-            missing=$((missing + 1))
+            missing_vars+=("${var}")
         fi
     done
 
-    if [[ ${missing} -gt 0 ]]; then
-        echo "ERROR: ${missing} required environment variable(s) missing — cannot start" >&2
+    if [[ ${#missing_vars[@]} -gt 0 ]]; then
+        echo "ERROR: ${#missing_vars[@]} required environment variable(s) missing — cannot start:" >&2
+        printf " - %s\n" "${missing_vars[@]}" >&2
+        return 1
+    fi
+
+    # Validate CLOUDRON_POSTGRESQL_PORT is a valid port number (1-65535)
+    if ! [[ "${CLOUDRON_POSTGRESQL_PORT}" =~ ^[0-9]+$ ]] ||
+        ((CLOUDRON_POSTGRESQL_PORT < 1 || CLOUDRON_POSTGRESQL_PORT > 65535)); then
+        echo "ERROR: CLOUDRON_POSTGRESQL_PORT must be an integer between 1 and 65535 (got: '${CLOUDRON_POSTGRESQL_PORT}')" >&2
         return 1
     fi
 
@@ -38,7 +45,7 @@ validate_env() {
     return 0
 }
 
-validate_env
+validate_env || exit 1
 
 # ============================================
 # PHASE 1: First-Run Detection


### PR DESCRIPTION
## Summary

- Refactors `validate_env()` to collect missing variables into an array and print a single consolidated error message with a bullet list, instead of individual error lines per variable (Gemini review feedback)
- Changes `validate_env` call to explicit `validate_env || exit 1` instead of relying on `set -e`, preventing unexpected behavior if `set -e` is temporarily disabled elsewhere (Gemini review feedback)
- Adds `CLOUDRON_POSTGRESQL_PORT` numeric and range validation (1-65535) to catch malformed injected values before DSN generation (CodeRabbit review feedback)

All three findings were medium-severity review comments from PR #9 that were merged without being addressed.

ShellCheck: zero violations.

Closes #14