### PR TITLE
t017: Add auth_secret loss consequence to persistent data warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ All persistent data is stored in `/app/data/` (Cloudron's `localstorage` addon) 
 | `/app/data/dashboard/` | Dashboard OIDC config (`config.json`, `.env`) |
 | `/app/data/.initialized` | First-run marker file |
 
-The encryption key encrypts setup keys and API tokens at rest in PostgreSQL. Both `.encryption_key` and `.auth_secret` are included in Cloudron backups. **Do not lose them** -- losing the encryption key means regenerating all setup keys and API tokens.
+The encryption key encrypts setup keys and API tokens at rest in PostgreSQL. Both `.encryption_key` and `.auth_secret` are included in Cloudron backups. **Do not lose them** -- losing the encryption key means regenerating all setup keys and API tokens, while losing the auth secret may disrupt relay server authentication.
 
 ## Development
 


### PR DESCRIPTION
## Summary

- Addresses quality-debt from PR #4 Gemini review feedback (medium severity)
- Adds documentation of `.auth_secret` loss consequence alongside the existing `.encryption_key` warning in the Persistent Data section

The warning previously only described the impact of losing `.encryption_key` (regenerating setup keys and API tokens). Now it also documents that losing `.auth_secret` may disrupt relay server authentication.

Closes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security documentation to clarify the impact of losing encryption keys and authentication secrets. Documented that losing an encryption key regenerates all setup keys and API tokens, and that losing an authentication secret may disrupt relay server authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->