### PR TITLE
t010: consolidate validate_env error reporting into single pass

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -19,25 +19,29 @@ validate_env() {
         "CLOUDRON_POSTGRESQL_DATABASE"
         "CLOUDRON_POSTGRESQL_PORT"
     )
-    local missing_vars=()
+    local errors=()
     local var
 
+    # Collect all missing required variables
     for var in "${required_vars[@]}"; do
         if [[ -z "${!var:-}" ]]; then
-            missing_vars+=("${var}")
+            errors+=("Required environment variable '${var}' is not set.")
         fi
     done
 
-    if [[ ${#missing_vars[@]} -gt 0 ]]; then
-        echo "ERROR: ${#missing_vars[@]} required environment variable(s) missing — cannot start:" >&2
-        printf " - %s\n" "${missing_vars[@]}" >&2
-        return 1
+    # Validate CLOUDRON_POSTGRESQL_PORT if it is present (PR #23 review:
+    # consolidate missing + invalid errors into a single report so the user
+    # can fix all configuration issues in one step)
+    if [[ -n "${CLOUDRON_POSTGRESQL_PORT:-}" ]]; then
+        if ! [[ "${CLOUDRON_POSTGRESQL_PORT}" =~ ^[0-9]+$ ]] ||
+            ((CLOUDRON_POSTGRESQL_PORT < 1 || CLOUDRON_POSTGRESQL_PORT > 65535)); then
+            errors+=("CLOUDRON_POSTGRESQL_PORT must be an integer between 1 and 65535 (got: '${CLOUDRON_POSTGRESQL_PORT}').")
+        fi
     fi
 
-    # Validate CLOUDRON_POSTGRESQL_PORT is a valid port number (1-65535)
-    if ! [[ "${CLOUDRON_POSTGRESQL_PORT}" =~ ^[0-9]+$ ]] ||
-        ((CLOUDRON_POSTGRESQL_PORT < 1 || CLOUDRON_POSTGRESQL_PORT > 65535)); then
-        echo "ERROR: CLOUDRON_POSTGRESQL_PORT must be an integer between 1 and 65535 (got: '${CLOUDRON_POSTGRESQL_PORT}')" >&2
+    if [[ ${#errors[@]} -gt 0 ]]; then
+        echo "ERROR: Environment validation failed with ${#errors[@]} error(s):" >&2
+        printf " - %s\n" "${errors[@]}" >&2
         return 1
     fi
 


### PR DESCRIPTION
## Summary

- Refactors `validate_env()` to collect both missing-variable and invalid-value errors into a single `errors` array, reporting all issues at once
- Previously, missing vars caused an early return before port validation ran — users had to fix missing vars first, then re-run to discover invalid port values
- Addresses the medium-severity Gemini review feedback from PR #23

## Changes

**`start.sh:13-50`** — `validate_env()` function:
- Replaced separate `missing_vars` array + early-return pattern with unified `errors` array
- Port validation now runs regardless of whether other vars are missing (guarded by `-n` check so it only validates if the var is present)
- Single error report at the end with count and bulleted list of all issues

## Verification

- `shellcheck start.sh` — clean (only SC2153 info-level false positive on Cloudron env vars)
- Logic review: if `CLOUDRON_POSTGRESQL_PORT` is missing, it gets reported as missing; if present but invalid, it gets reported as invalid; both can appear in the same error output

Closes #25