### PR TITLE
t011: Security posture — branch protection and security baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps):"

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,13 @@
 .DS_Store
 Thumbs.db
 
+# Secrets
+.env
+.env.*
+*.pem
+*.key
+credentials.json
+
 # Editor
 *.swp
 *.swo

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 2.x     | Yes       |
+| < 2.0   | No        |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this Cloudron app package,
+please report it responsibly.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, please email: **security@marcusquinn.com**
+
+Include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected versions
+- Any potential impact assessment
+
+You should receive an acknowledgement within 48 hours. We will work with
+you to understand the issue and coordinate a fix before any public
+disclosure.
+
+## Scope
+
+This security policy covers the **Cloudron app packaging** (Dockerfile,
+start.sh, nginx config, supervisord config, manifest). For vulnerabilities
+in NetBird itself, please report to the
+[upstream project](https://github.com/netbirdio/netbird/security).
+
+## Security Measures
+
+This package implements the following security measures:
+
+- **Branch protection**: PRs require at least 1 approving review before
+  merge to `main`
+- **Automated dependency updates**: Dependabot monitors Docker base images
+  and GitHub Actions
+- **Secret patterns in .gitignore**: `.env`, `*.pem`, `*.key`, and
+  `credentials.json` are excluded from version control
+- **Runtime secrets**: Encryption keys and auth secrets are generated at
+  first run and persisted in `/app/data/config/` (not in the image)
+- **nginx hardening**: Security headers (X-Frame-Options,
+  X-Content-Type-Options, etc.) are set in the nginx config
+- **Non-root nginx**: nginx worker processes run as the `cloudron` user


### PR DESCRIPTION
## Summary

Addresses all findings from the security audit sweep (issue #27):

- **Branch protection** enabled on `main` via GitHub API — requires 1 approving review, dismisses stale reviews
- **SECURITY.md** added with vulnerability reporting policy, scope definition (this package vs upstream NetBird), and security measures documentation
- **Dependabot** configured for Docker base image and GitHub Actions dependency updates (weekly)
- **.gitignore** updated with secret file patterns: `.env`, `.env.*`, `*.pem`, `*.key`, `credentials.json`

## What changed

| File | Change |
|------|--------|
| `SECURITY.md` | New — vulnerability reporting policy and security measures |
| `.github/dependabot.yml` | New — weekly Docker + GitHub Actions updates |
| `.gitignore` | Added secrets section with common credential patterns |
| GitHub API | Branch protection rule applied to `main` |

## Verification

- [x] Branch protection active: `gh api repos/marcusquinn/cloudron-netbird-app/branches/main/protection` returns 200
- [x] SECURITY.md follows GitHub's security policy format
- [x] Dependabot config validates against [schema](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)
- [x] .gitignore patterns cover all items from issue #27

Closes #27