### PR TITLE
GH#36: Explain supervisor dashboard freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,16 @@ cloudron uninstall --app netbird
 - [ ] STUN port (UDP 3478) is accessible from clients
 - [ ] (Optional) Cloudron SSO can be added as external IdP via dashboard
 
+### Repository Automation Dashboard
+
+The pinned supervisor health issue reports repository-development activity; it
+is not the deployed NetBird application's health check. Its refresh can pause
+while the repository has no active pull requests, assigned issues,
+auto-dispatch work, or workers. Before treating an old `last_refresh:` value as
+a scheduler or application failure, confirm that the stats launch agent is
+loaded and that recent stats-log entries end with a successful health-issue
+update.
+
 ## File Structure
 
 ```text


### PR DESCRIPTION
## Summary

Documented that the pinned supervisor dashboard measures repository activity rather than deployed app health; diagnosed the scheduler as healthy and refreshed dashboard #1 through the targeted stats updater.

## Files Changed

README.md

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — git diff --check passed; changed README lines have no markdownlint findings; dashboard #1 now contains last_refresh: 2026-07-22T21:34:06Z and updated_at 2026-07-22T21:37:24Z

Resolves #36


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.166 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 18m and 131,135 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for interpreting the Repository Automation Dashboard’s supervisor health status.
  * Clarified when dashboard refreshes may pause due to a lack of active work.
  * Documented how to validate the last refresh time before reporting a scheduler or application issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->