### PR TITLE
t013: chore(release): publish NetBird catalog 2.0.2

### DIFF
--- a/CloudronVersions.json
+++ b/CloudronVersions.json
@@ -51,8 +51,8 @@
                 "dockerImage": "marcusquinn/cloudron-netbird-app:2.0.2"
             },
             "creationDate": "Fri, 24 Jul 2026 00:40:03 GMT",
-            "ts": "Fri, 24 Jul 2026 00:40:03 GMT",
-            "publishState": "testing"
+            "ts": "Fri, 24 Jul 2026 00:49:19 GMT",
+            "publishState": "published"
         }
     }
 }

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -22,7 +22,7 @@ the catalog.
    `cloudron install --versions-url <PUBLIC_VERSIONS_URL> --location netbird-test`.
    Also verify upgrade, restart, health checks, and backup/restore.
 6. Promote only the tested package with
-   `cloudron versions update --version <VERSION> --state published`, then
+   `cloudron versions update --version=<VERSION> --state=published`, then
    publish the updated catalog.
 7. Optionally sign in to [Cloudron Community Apps](https://ca.cloudron.io), add
    the same versions URL, and verify the imported icon, screenshot/hero,

--- a/TODO.md
+++ b/TODO.md
@@ -59,6 +59,8 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 
 - [ ] t012 Prepare NetBird community package publishing ref:GH#43
 
+- [ ] t013 Publish NetBird 2.0.2 Cloudron catalog ref:GH#46
+
 ## In Progress
 
 <!--TOON:in_progress[0]{id,desc,owner,tags,est,risk,logged,started,status}:

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -29,6 +29,8 @@ main() {
 	[[ -f "${ROOT_DIR}/media/hero.png" ]] || fail "media/hero.png is missing" || return 1
 	jq -e '.stable == true and (.versions | type == "object")' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Version catalog contract failed" || return 1
 	assert_contains CHANGELOG '[2.0.2]' || return 1
+	assert_contains PUBLISHING.md 'cloudron versions update --version=<VERSION> --state=published' || return 1
+	jq -e '.versions["2.0.2"].publishState == "published"' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Published catalog state contract failed" || return 1
 	assert_contains Dockerfile 'netbirdio/netbird-server:0.74.7@sha256:ec97e2fcdf9666af849c293eeaaf0f4ff742f4f6e886d8873f129de8f4f6b7ef AS server' || return 1
 	assert_contains Dockerfile 'netbirdio/dashboard:v2.90.4@sha256:789c274741fdd78b870480dc700b8e6a5a67a4c4016abd2b6b0a1f34bd0fdd41 AS dashboard' || return 1
 	assert_contains Dockerfile 'cloudron/base:5.0.0@sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c' || return 1


### PR DESCRIPTION
## Summary

Promote the runtime-tested 2.0.2 registry image to published in CloudronVersions.json and document the Cloudron CLI 7.0.4 equals-form option syntax.

## Files Changed

CloudronVersions.json, PUBLISHING.md, TODO.md, test/package-test.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — runtime-verified: a fresh amd64 container started NetBird and Nginx against PostgreSQL, OpenID discovery returned HTTP 200, restart stayed healthy, and package contract and manifest validation passed after promotion.

Resolves #46


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.177 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 2h 38m and 1,100,370 tokens on this with the user in an interactive session.