### PR TITLE
GH#49: Link NetBird package repository

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 [2.0.3]
 * Update the combined NetBird server to v0.75.0.
 * Update the NetBird dashboard to v2.90.7.
+* Link the package repository and require Cloudron 10.0.0.
 
 [2.0.2]
 * Add Cloudron community catalog metadata and publishing runbook.

--- a/CloudronManifest.json
+++ b/CloudronManifest.json
@@ -13,7 +13,7 @@
   "contactEmail": "marcus@marcusquinn.com",
   "icon": "file://logo.png",
   "documentationUrl": "https://docs.netbird.io",
-  "minBoxVersion": "9.1.0",
+  "minBoxVersion": "10.0.0",
   "memoryLimit": 536870912,
   "optionalSso": true,
   "addons": {
@@ -41,6 +41,7 @@
   "iconUrl": "https://raw.githubusercontent.com/marcusquinn/cloudron-netbird-app/main/logo.png",
   "packagerName": "Marcus Quinn",
   "packagerUrl": "https://github.com/marcusquinn",
+  "packageUrl": "https://github.com/marcusquinn/cloudron-netbird-app",
   "mediaLinks": [
     "https://netbird.io/_next/static/media/centralized-network-management.67616bd3.png"
   ]

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -21,7 +21,7 @@ assert_contains() {
 }
 
 main() {
-	jq -e '.manifestVersion == 2 and .version == "2.0.3" and .upstreamVersion == "0.75.0" and .minBoxVersion == "9.1.0" and .iconUrl != "" and .packagerName != "" and .packagerUrl != "" and (.mediaLinks | length) > 0 and .changelog == "file://CHANGELOG"' \
+	jq -e '.manifestVersion == 2 and .version == "2.0.3" and .upstreamVersion == "0.75.0" and .minBoxVersion == "10.0.0" and .iconUrl != "" and .packagerName != "" and .packagerUrl == "https://github.com/marcusquinn" and .packageUrl == "https://github.com/marcusquinn/cloudron-netbird-app" and (.mediaLinks | length) > 0 and .changelog == "file://CHANGELOG"' \
 		"${ROOT_DIR}/CloudronManifest.json" >/dev/null || fail "Manifest version contract failed" || return 1
 	[[ -f "${ROOT_DIR}/CloudronVersions.json" ]] || fail "CloudronVersions.json is missing" || return 1
 	[[ -f "${ROOT_DIR}/PUBLISHING.md" ]] || fail "PUBLISHING.md is missing" || return 1


### PR DESCRIPTION
## Summary

Add the package repository link, retain maintainer provenance, require Cloudron 10.0.0, and cover the metadata contract.

## Files Changed

CHANGELOG, CloudronManifest.json, test/package-test.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash test/package-test.sh; git diff --check

Resolves #49


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.179 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 3h 40m and 1,493,661 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated the minimum required Cloudron version to 10.0.0.

* **Package Information**
  * Added a link to the app’s package repository.

* **Documentation**
  * Updated the 2.0.3 changelog with the new Cloudron requirement and repository link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->