### PR TITLE
GH#51: Publish NetBird catalog 2.0.3

### DIFF
--- a/CloudronVersions.json
+++ b/CloudronVersions.json
@@ -53,6 +53,60 @@
             "creationDate": "Fri, 24 Jul 2026 00:40:03 GMT",
             "ts": "Fri, 24 Jul 2026 00:49:19 GMT",
             "publishState": "published"
+        },
+        "2.0.3": {
+            "manifest": {
+                "id": "io.netbird.cloudronapp",
+                "title": "NetBird",
+                "author": "Marcus Quinn <marcus@marcusquinn.com>",
+                "description": "Self-hosted WireGuard mesh VPN with SSO, MFA, and granular access controls. Connect devices into a secure peer-to-peer overlay network.",
+                "tagline": "Zero-config WireGuard mesh VPN for teams",
+                "version": "2.0.3",
+                "upstreamVersion": "0.75.0",
+                "healthCheckPath": "/oauth2/.well-known/openid-configuration",
+                "httpPort": 8080,
+                "manifestVersion": 2,
+                "website": "https://netbird.io",
+                "contactEmail": "marcus@marcusquinn.com",
+                "icon": "file://logo.png",
+                "documentationUrl": "https://docs.netbird.io",
+                "minBoxVersion": "10.0.0",
+                "memoryLimit": 536870912,
+                "optionalSso": true,
+                "addons": {
+                    "localstorage": {},
+                    "postgresql": {}
+                },
+                "udpPorts": {
+                    "STUN_PORT": {
+                        "title": "STUN (NAT traversal)",
+                        "description": "UDP port for STUN NAT traversal. Must be accessible from all NetBird clients.",
+                        "defaultValue": 3478,
+                        "containerPort": 3478
+                    }
+                },
+                "tags": [
+                    "vpn",
+                    "wireguard",
+                    "mesh",
+                    "networking",
+                    "security"
+                ],
+                "postInstallMessage": "NetBird is running. Visit the app URL to access the dashboard.\n\nOn first run, you will see the setup page where you can create your admin account.\n\nUDP port ${STUN_PORT} must be accessible from your NetBird clients for NAT traversal.\n\n<sso>Cloudron SSO can be added as an external identity provider via Settings > Identity Providers in the NetBird dashboard after initial setup.</sso>",
+                "configurePath": "/peers",
+                "changelog": "* Update the combined NetBird server to v0.75.0.\n* Update the NetBird dashboard to v2.90.7.\n* Link the package repository and require Cloudron 10.0.0.\n",
+                "iconUrl": "https://raw.githubusercontent.com/marcusquinn/cloudron-netbird-app/main/logo.png",
+                "packagerName": "Marcus Quinn",
+                "packagerUrl": "https://github.com/marcusquinn",
+                "packageUrl": "https://github.com/marcusquinn/cloudron-netbird-app",
+                "mediaLinks": [
+                    "https://netbird.io/_next/static/media/centralized-network-management.67616bd3.png"
+                ],
+                "dockerImage": "marcusquinn/cloudron-netbird-app:2.0.3"
+            },
+            "creationDate": "Fri, 24 Jul 2026 02:12:15 GMT",
+            "ts": "Fri, 24 Jul 2026 02:13:01 GMT",
+            "publishState": "published"
         }
     }
 }


### PR DESCRIPTION
## Summary

Append the image-backed 2.0.3 entry and publish it with Cloudron 10 package repository metadata while preserving 2.0.2.

## Files Changed

CloudronVersions.json

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — bash test/package-test.sh; exact jq catalog assertions; cloudron versions list; registry digest sha256:dea5f22f249e90faa2fd691a1cab5b841c998c1e6fb5fbf160036f0b45ce6a21. Clean install was unavailable because the connected pre-10 Cloudron rejects packageUrl.

Resolves #51


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 3h 58m and 1,577,448 tokens on this with the user in an interactive session.