### PR TITLE
t016: restore Cloudron 9.2 compatibility

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+[2.0.4]
+* Restore installation and updates on Cloudron 9.1 and 9.2.
+* Temporarily omit packageUrl until Cloudron 10.0.0 is numerically available.
+
 [2.0.3]
 * Update the combined NetBird server to v0.75.0.
 * Update the NetBird dashboard to v2.90.7.

--- a/CloudronManifest.json
+++ b/CloudronManifest.json
@@ -4,7 +4,7 @@
   "author": "Marcus Quinn <marcus@marcusquinn.com>",
   "description": "Self-hosted WireGuard mesh VPN with SSO, MFA, and granular access controls. Connect devices into a secure peer-to-peer overlay network.",
   "tagline": "Zero-config WireGuard mesh VPN for teams",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "upstreamVersion": "0.75.0",
   "healthCheckPath": "/oauth2/.well-known/openid-configuration",
   "httpPort": 8080,
@@ -13,7 +13,7 @@
   "contactEmail": "marcus@marcusquinn.com",
   "icon": "file://logo.png",
   "documentationUrl": "https://docs.netbird.io",
-  "minBoxVersion": "10.0.0",
+  "minBoxVersion": "9.1.0",
   "memoryLimit": 536870912,
   "optionalSso": true,
   "addons": {
@@ -41,7 +41,6 @@
   "iconUrl": "https://raw.githubusercontent.com/marcusquinn/cloudron-netbird-app/main/logo.png",
   "packagerName": "Marcus Quinn",
   "packagerUrl": "https://github.com/marcusquinn",
-  "packageUrl": "https://github.com/marcusquinn/cloudron-netbird-app",
   "mediaLinks": [
     "https://netbird.io/_next/static/media/centralized-network-management.67616bd3.png"
   ]

--- a/TODO.md
+++ b/TODO.md
@@ -61,6 +61,8 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 
 - [ ] t013 Publish NetBird 2.0.2 Cloudron catalog ref:GH#46
 
+- [ ] t016 Restore Cloudron 9.2 compatibility ref:GH#53
+
 ## In Progress
 
 <!--TOON:in_progress[0]{id,desc,owner,tags,est,risk,logged,started,status}:

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -21,16 +21,16 @@ assert_contains() {
 }
 
 main() {
-	jq -e '.manifestVersion == 2 and .version == "2.0.3" and .upstreamVersion == "0.75.0" and .minBoxVersion == "10.0.0" and .iconUrl != "" and .packagerName != "" and .packagerUrl == "https://github.com/marcusquinn" and .packageUrl == "https://github.com/marcusquinn/cloudron-netbird-app" and (.mediaLinks | length) > 0 and .changelog == "file://CHANGELOG"' \
+	jq -e '.manifestVersion == 2 and .version == "2.0.4" and .upstreamVersion == "0.75.0" and .minBoxVersion == "9.1.0" and .iconUrl != "" and .packagerName != "" and .packagerUrl == "https://github.com/marcusquinn" and (has("packageUrl") | not) and (.mediaLinks | length) > 0 and .changelog == "file://CHANGELOG"' \
 		"${ROOT_DIR}/CloudronManifest.json" >/dev/null || fail "Manifest version contract failed" || return 1
 	[[ -f "${ROOT_DIR}/CloudronVersions.json" ]] || fail "CloudronVersions.json is missing" || return 1
 	[[ -f "${ROOT_DIR}/PUBLISHING.md" ]] || fail "PUBLISHING.md is missing" || return 1
 	[[ -f "${ROOT_DIR}/DESIGN.md" ]] || fail "DESIGN.md is missing" || return 1
 	[[ -f "${ROOT_DIR}/media/hero.png" ]] || fail "media/hero.png is missing" || return 1
 	jq -e '.stable == true and (.versions | type == "object")' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Version catalog contract failed" || return 1
-	assert_contains CHANGELOG '[2.0.3]' || return 1
+	assert_contains CHANGELOG '[2.0.4]' || return 1
 	assert_contains PUBLISHING.md 'cloudron versions update --version=<VERSION> --state=published' || return 1
-	jq -e '.versions["2.0.2"].publishState == "published"' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Published catalog state contract failed" || return 1
+	jq -e '.versions["2.0.3"].publishState == "published"' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Published catalog state contract failed" || return 1
 	assert_contains Dockerfile 'netbirdio/netbird-server:0.75.0@sha256:9f8dbb2fee412f91acee1a280c6c06fe8a7bea7b615c37530d6a7bba2edcf901 AS server' || return 1
 	assert_contains Dockerfile 'netbirdio/dashboard:v2.90.7@sha256:4b9d5eedede5b55737546124162f15ba0c79a32e78ba4c3218549be96ad22fb1 AS dashboard' || return 1
 	assert_contains Dockerfile 'cloudron/base:5.0.0@sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c' || return 1


### PR DESCRIPTION
## Summary

Bump NetBird to 2.0.4, remove the Cloudron-10-only packageUrl field, restore minBoxVersion 9.1.0, and add a regression assertion.

## Files Changed

CHANGELOG, CloudronManifest.json, TODO.md, test/package-test.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — jq validation and test/package-test.sh pass; Cloudron CLI schema validation will run during catalog generation.

Resolves #53


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 4h 48m and 1,919,885 tokens on this with the user in an interactive session.