### PR TITLE
t017: publish NetBird catalog 2.0.4

### DIFF
--- a/CloudronVersions.json
+++ b/CloudronVersions.json
@@ -107,6 +107,59 @@
             "creationDate": "Fri, 24 Jul 2026 02:12:15 GMT",
             "ts": "Fri, 24 Jul 2026 02:13:01 GMT",
             "publishState": "published"
+        },
+        "2.0.4": {
+            "manifest": {
+                "id": "io.netbird.cloudronapp",
+                "title": "NetBird",
+                "author": "Marcus Quinn <marcus@marcusquinn.com>",
+                "description": "Self-hosted WireGuard mesh VPN with SSO, MFA, and granular access controls. Connect devices into a secure peer-to-peer overlay network.",
+                "tagline": "Zero-config WireGuard mesh VPN for teams",
+                "version": "2.0.4",
+                "upstreamVersion": "0.75.0",
+                "healthCheckPath": "/oauth2/.well-known/openid-configuration",
+                "httpPort": 8080,
+                "manifestVersion": 2,
+                "website": "https://netbird.io",
+                "contactEmail": "marcus@marcusquinn.com",
+                "icon": "file://logo.png",
+                "documentationUrl": "https://docs.netbird.io",
+                "minBoxVersion": "9.1.0",
+                "memoryLimit": 536870912,
+                "optionalSso": true,
+                "addons": {
+                    "localstorage": {},
+                    "postgresql": {}
+                },
+                "udpPorts": {
+                    "STUN_PORT": {
+                        "title": "STUN (NAT traversal)",
+                        "description": "UDP port for STUN NAT traversal. Must be accessible from all NetBird clients.",
+                        "defaultValue": 3478,
+                        "containerPort": 3478
+                    }
+                },
+                "tags": [
+                    "vpn",
+                    "wireguard",
+                    "mesh",
+                    "networking",
+                    "security"
+                ],
+                "postInstallMessage": "NetBird is running. Visit the app URL to access the dashboard.\n\nOn first run, you will see the setup page where you can create your admin account.\n\nUDP port ${STUN_PORT} must be accessible from your NetBird clients for NAT traversal.\n\n<sso>Cloudron SSO can be added as an external identity provider via Settings > Identity Providers in the NetBird dashboard after initial setup.</sso>",
+                "configurePath": "/peers",
+                "changelog": "* Restore installation and updates on Cloudron 9.1 and 9.2.\n* Temporarily omit packageUrl until Cloudron 10.0.0 is numerically available.\n",
+                "iconUrl": "https://raw.githubusercontent.com/marcusquinn/cloudron-netbird-app/main/logo.png",
+                "packagerName": "Marcus Quinn",
+                "packagerUrl": "https://github.com/marcusquinn",
+                "mediaLinks": [
+                    "https://netbird.io/_next/static/media/centralized-network-management.67616bd3.png"
+                ],
+                "dockerImage": "marcusquinn/cloudron-netbird-app:2.0.4"
+            },
+            "creationDate": "Fri, 24 Jul 2026 03:20:01 GMT",
+            "ts": "Fri, 24 Jul 2026 03:20:49 GMT",
+            "publishState": "published"
         }
     }
 }

--- a/TODO.md
+++ b/TODO.md
@@ -63,6 +63,8 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 
 - [ ] t016 Restore Cloudron 9.2 compatibility ref:GH#53
 
+- [ ] t017 Publish NetBird 2.0.4 Cloudron catalog ref:GH#55
+
 ## In Progress
 
 <!--TOON:in_progress[0]{id,desc,owner,tags,est,risk,logged,started,status}:


### PR DESCRIPTION
## Summary

Publish the Cloudron CLI-generated NetBird 2.0.4 catalog entry using the pushed amd64 registry image.

## Files Changed

CloudronVersions.json, TODO.md

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Package tests, JSON validation, exact catalog assertions, image architecture inspection, and Cloudron CLI testing-to-published transition pass.

Resolves #55


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 5h 6m and 1,989,728 tokens on this with the user in an interactive session.