### PR TITLE
t018: validate NetBird 2.0.4 release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.4] - 2026-07-24
+
+### Fixed
+
+- Restored Cloudron 9.1 and 9.2 installation and update compatibility by
+  temporarily omitting `packageUrl` until Cloudron 10.0.0 is numerically
+  available.
+
 ## [2.0.3] - 2026-07-24
 
 ### Changed

--- a/TODO.md
+++ b/TODO.md
@@ -65,6 +65,8 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 
 - [ ] t017 Publish NetBird 2.0.4 Cloudron catalog ref:GH#55
 
+- [ ] t018 Fix NetBird 2.0.4 release changelog validation ref:GH#57
+
 ## In Progress
 
 <!--TOON:in_progress[0]{id,desc,owner,tags,est,risk,logged,started,status}:

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -29,6 +29,7 @@ main() {
 	[[ -f "${ROOT_DIR}/media/hero.png" ]] || fail "media/hero.png is missing" || return 1
 	jq -e '.stable == true and (.versions | type == "object")' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Version catalog contract failed" || return 1
 	assert_contains CHANGELOG '[2.0.4]' || return 1
+	assert_contains CHANGELOG.md '[2.0.4]' || return 1
 	assert_contains PUBLISHING.md 'cloudron versions update --version=<VERSION> --state=published' || return 1
 	jq -e '.versions["2.0.3"].publishState == "published"' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Published catalog state contract failed" || return 1
 	assert_contains Dockerfile 'netbirdio/netbird-server:0.75.0@sha256:9f8dbb2fee412f91acee1a280c6c06fe8a7bea7b615c37530d6a7bba2edcf901 AS server' || return 1


### PR DESCRIPTION
## Summary

Add the missing Keep a Changelog section for NetBird 2.0.4 and require both release changelog formats in package tests.

## Files Changed

CHANGELOG.md, TODO.md, test/package-test.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — test/package-test.sh, ShellCheck, git diff --check, and cloudron-package-helper.sh check-release v2.0.4 pass.

Resolves #57


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-sol spent 5h 16m and 2,070,276 tokens on this with the user in an interactive session.