### PR TITLE
GH#60: harden linked issue workflow caller

### DIFF
--- a/.github/workflows/linked-issue-check.yml
+++ b/.github/workflows/linked-issue-check.yml
@@ -13,6 +13,7 @@ name: Linked Issue Check
 # a repository ruleset.
 
 permissions:
+  issues: read
   pull-requests: read
   statuses: write
 
@@ -22,4 +23,4 @@ on:
 
 jobs:
   check:
-    uses: marcusquinn/aidevops/.github/workflows/linked-issue-check-reusable.yml@main
+    uses: marcusquinn/aidevops/.github/workflows/linked-issue-check-reusable.yml@f5ac0cecd63b315a7409ed492216bb6a153b94a3


### PR DESCRIPTION
## Summary

Grant the reusable workflow issues read access and pin the caller to the current immutable aidevops commit

## Files Changed

.github/workflows/linked-issue-check.yml

## Runtime Testing

- **Risk level:** Low
- **Verification:** self-assessed — actionlint .github/workflows/linked-issue-check.yml; git diff --check

Resolves #60


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.195 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 6m and 45,265 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow permissions to support issue checks.
  * Pinned the linked-issue validation workflow to a specific revision for more consistent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->