### PR TITLE
t020: Automate Cloudron releases after package updates merge

### DIFF
--- a/.github/workflows/cloudron-catalog-publish.yml
+++ b/.github/workflows/cloudron-catalog-publish.yml
@@ -198,9 +198,8 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git commit -m "chore: publish Cloudron package ${RELEASE_VERSION}"
-          git push origin HEAD:main
           git tag -a "v${RELEASE_VERSION}" -m "Release v${RELEASE_VERSION}"
-          git push origin "v${RELEASE_VERSION}"
+          git push --atomic origin HEAD:main "v${RELEASE_VERSION}"
 
       - name: Create GitHub release
         env:
@@ -230,3 +229,45 @@ jobs:
         env:
           IMMUTABLE_REF: ${{ needs.preflight.outputs.immutable_ref }}
         run: docker buildx imagetools inspect "${IMMUTABLE_REF}"
+
+  reconcile-existing-release:
+    needs:
+      - preflight
+      - verify-existing
+    if: github.event_name != 'pull_request' && needs.preflight.outputs.publish == 'false'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Check out published source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.preflight.outputs.before_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify existing package tag and digest
+        env:
+          IMMUTABLE_REF: ${{ needs.preflight.outputs.immutable_ref }}
+          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          set -euo pipefail
+          tagged_image_ref="$(
+            git show "v${RELEASE_VERSION}:CloudronVersions.json" |
+              jq -r --arg version "${RELEASE_VERSION}" '.versions[$version].manifest.dockerImage'
+          )"
+          test "${tagged_image_ref}" = "${IMMUTABLE_REF}"
+
+      - name: Reconcile GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
+          UPSTREAM_VERSION: ${{ needs.preflight.outputs.upstream_version }}
+        run: |
+          if gh release view "v${RELEASE_VERSION}" >/dev/null 2>&1; then
+            exit 0
+          fi
+          gh release create "v${RELEASE_VERSION}" \
+            --verify-tag \
+            --title "v${RELEASE_VERSION}" \
+            --notes "Cloudron package ${RELEASE_VERSION} for NetBird ${UPSTREAM_VERSION}."

--- a/.github/workflows/cloudron-catalog-publish.yml
+++ b/.github/workflows/cloudron-catalog-publish.yml
@@ -34,6 +34,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Require trusted publication source
+        if: github.event_name != 'pull_request'
+        env:
+          ACTUAL_REF: ${{ github.ref }}
+          EXPECTED_REF: refs/heads/main
+        run: |
+          set -euo pipefail
+          test "${ACTUAL_REF}" = "${EXPECTED_REF}"
+
       - name: Validate package
         run: bash ./test/package-test.sh
 
@@ -214,5 +223,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Report verified no-op
-        run: printf 'Cloudron package %s is already published as %s\n' '${{ needs.preflight.outputs.version }}' '${{ needs.preflight.outputs.immutable_ref }}'
+      - name: Set up Docker Buildx for anonymous verification
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Verify existing immutable image is anonymously pullable
+        env:
+          IMMUTABLE_REF: ${{ needs.preflight.outputs.immutable_ref }}
+        run: docker buildx imagetools inspect "${IMMUTABLE_REF}"

--- a/.github/workflows/cloudron-catalog-publish.yml
+++ b/.github/workflows/cloudron-catalog-publish.yml
@@ -29,7 +29,7 @@ jobs:
       immutable_ref: ${{ steps.existing.outputs.immutable_ref }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f544c9b2a8e # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -88,7 +88,7 @@ jobs:
       image_ref: ${{ steps.image.outputs.image_ref }}
     steps:
       - name: Check out the verified revision
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f544c9b2a8e # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.preflight.outputs.before_sha }}
           fetch-depth: 1
@@ -140,7 +140,7 @@ jobs:
       contents: write
     steps:
       - name: Check out the verified revision
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f544c9b2a8e # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.preflight.outputs.before_sha }}
           fetch-depth: 0

--- a/.github/workflows/cloudron-catalog-publish.yml
+++ b/.github/workflows/cloudron-catalog-publish.yml
@@ -1,0 +1,218 @@
+name: Publish Cloudron Catalog
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: cloudron-catalog-publish
+  cancel-in-progress: false
+
+env:
+  IMAGE_REPOSITORY: ghcr.io/marcusquinn/cloudron-netbird-app
+  CLOUDRON_CLI_VERSION: 8.2.6
+  CLOUDRON_CLI_INTEGRITY: sha512-tyrKq6d6F/s3MqN9LB43+/fWp+7Q4oVujcOYkIv78gWYMHlhi5OsrRpKbXogJItyjo/yeyR/ZX6oHgRCHHyx3w==
+
+jobs:
+  preflight:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      publish: ${{ steps.decide.outputs.publish }}
+      version: ${{ steps.manifest.outputs.version }}
+      upstream_version: ${{ steps.manifest.outputs.upstream_version }}
+      before_sha: ${{ steps.manifest.outputs.before_sha }}
+      immutable_ref: ${{ steps.existing.outputs.immutable_ref }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f544c9b2a8e # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate package
+        run: bash ./test/package-test.sh
+
+      - name: Validate catalog publisher
+        run: bash ./test/publish-catalog-test.sh
+
+      - name: Read manifest metadata
+        id: manifest
+        run: |
+          version="$(jq -r '.version' CloudronManifest.json)"
+          upstream_version="$(jq -r '.upstreamVersion' CloudronManifest.json)"
+          test -n "${version}" && test "${version}" != "null"
+          test -n "${upstream_version}" && test "${upstream_version}" != "null"
+          printf 'version=%s\n' "${version}" >> "${GITHUB_OUTPUT}"
+          printf 'upstream_version=%s\n' "${upstream_version}" >> "${GITHUB_OUTPUT}"
+          printf 'before_sha=%s\n' "${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
+
+      - name: Decide whether this version needs publication
+        id: decide
+        run: |
+          version="${{ steps.manifest.outputs.version }}"
+          if jq -e --arg version "${version}" '.versions[$version] != null' CloudronVersions.json >/dev/null; then
+            printf 'publish=false\n' >> "${GITHUB_OUTPUT}"
+          else
+            printf 'publish=true\n' >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Validate an existing release entry
+        id: existing
+        if: steps.decide.outputs.publish == 'false'
+        run: |
+          version="${{ steps.manifest.outputs.version }}"
+          image_ref="$(jq -r --arg version "${version}" '.versions[$version].manifest.dockerImage' CloudronVersions.json)"
+          publish_state="$(jq -r --arg version "${version}" '.versions[$version].publishState' CloudronVersions.json)"
+          test "${publish_state}" = "published"
+          case "${image_ref}" in
+            *@sha256:*) ;;
+            *) printf 'Existing release %s is not pinned to an immutable digest\n' "${version}" >&2; exit 1 ;;
+          esac
+          printf 'immutable_ref=%s\n' "${image_ref}" >> "${GITHUB_OUTPUT}"
+
+  build:
+    needs: preflight
+    if: github.event_name != 'pull_request' && needs.preflight.outputs.publish == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      image_ref: ${{ steps.image.outputs.image_ref }}
+    steps:
+      - name: Check out the verified revision
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f544c9b2a8e # v7.0.0
+        with:
+          ref: ${{ needs.preflight.outputs.before_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify the build source stayed immutable
+        run: test "$(git rev-parse HEAD)" = "${{ needs.preflight.outputs.before_sha }}"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build and push amd64 image
+        id: build
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.IMAGE_REPOSITORY }}:${{ needs.preflight.outputs.version }}
+
+      - name: Record immutable image reference
+        id: image
+        run: |
+          digest="${{ steps.build.outputs.digest }}"
+          test -n "${digest}"
+          printf 'image_ref=%s@%s\n' "${IMAGE_REPOSITORY}" "${digest}" >> "${GITHUB_OUTPUT}"
+
+      - name: Attest image provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-name: ${{ env.IMAGE_REPOSITORY }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+  publish:
+    needs:
+      - preflight
+      - build
+    if: github.event_name != 'pull_request' && needs.preflight.outputs.publish == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Check out the verified revision
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f544c9b2a8e # v7.0.0
+        with:
+          ref: ${{ needs.preflight.outputs.before_sha }}
+          fetch-depth: 0
+
+      - name: Verify the release source stayed immutable
+        run: test "$(git rev-parse HEAD)" = "${{ needs.preflight.outputs.before_sha }}"
+
+      - name: Install pinned Cloudron CLI
+        run: |
+          npm install --global --ignore-scripts "cloudron@${CLOUDRON_CLI_VERSION}"
+          installed_integrity="$(npm view "cloudron@${CLOUDRON_CLI_VERSION}" dist.integrity)"
+          test "${installed_integrity}" = "${CLOUDRON_CLI_INTEGRITY}"
+          test "$(cloudron --version)" = "${CLOUDRON_CLI_VERSION}"
+
+      - name: Set up Docker Buildx for anonymous verification
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Verify anonymous registry visibility
+        env:
+          EXPECTED_IMAGE_REF: ${{ needs.build.outputs.image_ref }}
+        run: |
+          for attempt in $(seq 1 12); do
+            if docker buildx imagetools inspect "${EXPECTED_IMAGE_REF}" >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep $((attempt * 5))
+          done
+          printf 'Timed out waiting for anonymous access to %s\n' "${EXPECTED_IMAGE_REF}" >&2
+          exit 1
+
+      - name: Publish and verify catalog entry
+        env:
+          EXPECTED_IMAGE_REF: ${{ needs.build.outputs.image_ref }}
+          EXPECTED_VERSION: ${{ needs.preflight.outputs.version }}
+        run: bash scripts/publish-cloudron-catalog.sh CloudronVersions.json "${EXPECTED_IMAGE_REF}" "${EXPECTED_VERSION}"
+
+      - name: Commit generated catalog
+        env:
+          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          before_sha="${{ needs.preflight.outputs.before_sha }}"
+          git diff --exit-code "${before_sha}" -- CloudronManifest.json CHANGELOG CHANGELOG.md
+          git add CloudronVersions.json
+          test -n "$(git diff --cached --name-only)"
+          test "$(git diff --cached --name-only)" = "CloudronVersions.json"
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git commit -m "chore: publish Cloudron package ${RELEASE_VERSION}"
+          git push origin HEAD:main
+          git tag -a "v${RELEASE_VERSION}" -m "Release v${RELEASE_VERSION}"
+          git push origin "v${RELEASE_VERSION}"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
+          UPSTREAM_VERSION: ${{ needs.preflight.outputs.upstream_version }}
+        run: |
+          if gh release view "v${RELEASE_VERSION}" >/dev/null 2>&1; then
+            exit 0
+          fi
+          gh release create "v${RELEASE_VERSION}" \
+            --verify-tag \
+            --title "v${RELEASE_VERSION}" \
+            --notes "Cloudron package ${RELEASE_VERSION} for NetBird ${UPSTREAM_VERSION}."
+
+  verify-existing:
+    needs: preflight
+    if: needs.preflight.outputs.publish == 'false'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Report verified no-op
+        run: printf 'Cloudron package %s is already published as %s\n' '${{ needs.preflight.outputs.version }}' '${{ needs.preflight.outputs.immutable_ref }}'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+[2.0.5]
+* Automate immutable Cloudron image and catalog publication after merged package updates.
+* Publish the Cloudron 9.1 and 9.2 compatibility repair through the managed release lifecycle.
+
 [2.0.4]
 * Restore installation and updates on Cloudron 9.1 and 9.2.
 * Temporarily omit packageUrl until Cloudron 10.0.0 is numerically available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.5] - 2026-07-30
+
+### Added
+
+- Added fail-closed publication after trusted package updates merge: the
+  workflow builds an amd64 image, resolves its immutable GHCR digest, generates
+  and verifies the catalog entry, and creates the matching tag and release.
+
+### Changed
+
+- Published the Cloudron 9.1 and 9.2 compatibility repair as a new immutable
+  package version through the managed release lifecycle.
+
 ## [2.0.4] - 2026-07-24
 
 ### Fixed

--- a/CloudronManifest.json
+++ b/CloudronManifest.json
@@ -4,7 +4,7 @@
   "author": "Marcus Quinn <marcus@marcusquinn.com>",
   "description": "Self-hosted WireGuard mesh VPN with SSO, MFA, and granular access controls. Connect devices into a secure peer-to-peer overlay network.",
   "tagline": "Zero-config WireGuard mesh VPN for teams",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "upstreamVersion": "0.75.0",
   "healthCheckPath": "/oauth2/.well-known/openid-configuration",
   "httpPort": 8080,

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM netbirdio/netbird-server:0.75.0@sha256:9f8dbb2fee412f91acee1a280c6c06fe8a7b
 FROM netbirdio/dashboard:v2.90.7@sha256:4b9d5eedede5b55737546124162f15ba0c79a32e78ba4c3218549be96ad22fb1 AS dashboard
 FROM cloudron/base:5.0.0@sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c
 
+LABEL org.opencontainers.image.source="https://github.com/marcusquinn/cloudron-netbird-app"
+
 # Install dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     nginx \

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -20,11 +20,12 @@ tag or digest into the catalog.
 4. The workflow runs `scripts/publish-cloudron-catalog.sh`, which adds the new
    manifest version in testing state, verifies the generated entry and digest,
    promotes that exact version to published, and verifies the final catalog.
-5. The workflow commits only the generated `CloudronVersions.json`, pushes the
-   matching `v<VERSION>` tag, attests the image digest, and creates the GitHub
-   release, but only after an anonymous pull probe resolves that exact digest.
-   Existing published versions are a verified no-op; mutable, unpublished, or
-   conflicting entries fail closed.
+5. The workflow commits only the generated `CloudronVersions.json`, atomically
+   pushes that commit with the matching `v<VERSION>` tag, attests the image
+   digest, and creates the GitHub release, but only after an anonymous pull
+   probe resolves that exact digest. Existing published versions reverify the
+   anonymous image and tagged catalog digest, then reconcile a missing GitHub
+   release. Mutable, unpublished, or conflicting entries fail closed.
 6. For release qualification, test a clean install with
    `cloudron install --versions-url <PUBLIC_VERSIONS_URL> --location netbird-test`.
    Also verify upgrade, restart, health checks, and backup/restore.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,9 +1,9 @@
 # Cloudron community publishing
 
-`CloudronVersions.json` is initialized but intentionally contains no release.
-Publishing requires a registry-hosted image built by the Cloudron CLI and
-separate operator authorization. Never hand-write an image tag or digest into
-the catalog.
+`CloudronVersions.json` is the public package catalog. Merging a completed
+package update to `main` is standing authorization for the managed publication
+workflow to build and publish that manifest version. Never hand-write an image
+tag or digest into the catalog.
 
 ## Release workflow
 
@@ -12,21 +12,28 @@ the catalog.
 2. Confirm `logo.png` is a 256×256 PNG and `media/hero.png` is a
    privacy-reviewed 3:1 image. Verify every `iconUrl` and `mediaLinks` URL
    returns an image over public HTTPS.
-3. Configure an operator-owned registry and run `cloudron build`. On a
-   non-amd64 builder, set `DOCKER_DEFAULT_PLATFORM=linux/amd64` so the
-   pinned Cloudron base and copied NetBird binaries use the same platform. Use
-   `cloudron build info` to verify the recorded repository and image.
-4. Add the candidate with `cloudron versions add --state testing`, host the
-   catalog at the intended public URL, and run `cloudron versions list`.
-5. Test a clean install with
+3. Merge the completed package update to `main`. The
+   `cloudron-catalog-publish.yml` workflow validates the package, builds the
+   amd64 image, pushes it to `ghcr.io/marcusquinn/cloudron-netbird-app`, and
+   resolves the immutable registry digest. The OCI source label links the
+   package to this public repository so Cloudron can pull it anonymously.
+4. The workflow runs `scripts/publish-cloudron-catalog.sh`, which adds the new
+   manifest version in testing state, verifies the generated entry and digest,
+   promotes that exact version to published, and verifies the final catalog.
+5. The workflow commits only the generated `CloudronVersions.json`, pushes the
+   matching `v<VERSION>` tag, attests the image digest, and creates the GitHub
+   release, but only after an anonymous pull probe resolves that exact digest.
+   Existing published versions are a verified no-op; mutable, unpublished, or
+   conflicting entries fail closed.
+6. For release qualification, test a clean install with
    `cloudron install --versions-url <PUBLIC_VERSIONS_URL> --location netbird-test`.
    Also verify upgrade, restart, health checks, and backup/restore.
-6. Promote only the tested package with
-   `cloudron versions update --version=<VERSION> --state=published`, then
-   publish the updated catalog.
 7. Optionally sign in to [Cloudron Community Apps](https://ca.cloudron.io), add
    the same versions URL, and verify the imported icon, screenshot/hero,
    description, changelog, and install URL.
+
+The workflow is the only supported catalog writer. A merge that does not bump
+`CloudronManifest.json` is a verified no-op and does not create another release.
 
 Published entries are append-only. For a critical bad release, run
 `cloudron versions revoke`, bump the package version, rebuild, and add a new

--- a/TODO.md
+++ b/TODO.md
@@ -69,6 +69,8 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 
 - [ ] t019 Repair historical catalog entry for Cloudron 9.2 #bug ref:GH#62
 
+- [ ] t020 Automate Cloudron releases after package updates merge #feat #priority:high ref:GH#64
+
 ## In Progress
 
 <!--TOON:in_progress[0]{id,desc,owner,tags,est,risk,logged,started,status}:

--- a/scripts/publish-cloudron-catalog.sh
+++ b/scripts/publish-cloudron-catalog.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+set -euo pipefail
+
+fail() {
+	local message="$1"
+	printf 'ERROR: %s\n' "$message" >&2
+	return 1
+}
+
+resolve_version_key() {
+	local catalog_path="$1"
+	local expected_version="$2"
+	local image_ref="$3"
+	local matching_keys=""
+	local key_count=""
+	local manifest_version=""
+
+	matching_keys="$(jq -r --arg image "$image_ref" '[.versions | to_entries[] | select(.value.manifest.dockerImage == $image) | .key] | .[]' "$catalog_path")" || return 1
+	key_count="$(printf '%s\n' "$matching_keys" | awk 'NF { count += 1 } END { print count + 0 }')"
+	[[ "$key_count" == "1" ]] || fail "Expected exactly one generated catalog entry for ${image_ref}, found ${key_count}" || return 1
+	[[ "$matching_keys" == "$expected_version" ]] || fail "Generated catalog key ${matching_keys} does not match expected version ${expected_version}" || return 1
+
+	manifest_version="$(jq -r --arg version "$expected_version" '.versions[$version].manifest.version // empty' "$catalog_path")" || return 1
+	[[ "$manifest_version" == "$expected_version" ]] || fail "Generated manifest version ${manifest_version:-<missing>} does not match ${expected_version}" || return 1
+
+	printf '%s\n' "$matching_keys"
+	return 0
+}
+
+verify_entry() {
+	local catalog_path="$1"
+	local expected_version="$2"
+	local expected_state="$3"
+	local expected_image="$4"
+	local catalog_image=""
+	local catalog_state=""
+
+	catalog_image="$(jq -r --arg version "$expected_version" '.versions[$version].manifest.dockerImage // empty' "$catalog_path")" || return 1
+	catalog_state="$(jq -r --arg version "$expected_version" '.versions[$version].publishState // empty' "$catalog_path")" || return 1
+
+	[[ "$catalog_image" == "$expected_image" ]] || fail "Catalog image ${catalog_image:-<missing>} does not match ${expected_image}" || return 1
+	[[ "$catalog_state" == "$expected_state" ]] || fail "Catalog state ${catalog_state:-<missing>} does not match ${expected_state}" || return 1
+	return 0
+}
+
+main() {
+	local catalog_path="${1:-CloudronVersions.json}"
+	local image_ref="${2:-${EXPECTED_IMAGE_REF:-}}"
+	local expected_version="${3:-${EXPECTED_VERSION:-}}"
+	local generated_key=""
+
+	[[ -f "$catalog_path" ]] || fail "Catalog not found: ${catalog_path}" || return 1
+	[[ "$catalog_path" == "CloudronVersions.json" ]] || fail "Cloudron CLI 8.2.6 requires the catalog path CloudronVersions.json" || return 1
+	[[ -n "$image_ref" ]] || fail "An immutable image reference is required" || return 1
+	[[ "$image_ref" == *@sha256:* ]] || fail "Image reference must use an immutable sha256 digest" || return 1
+	[[ -n "$expected_version" ]] || fail "An expected package version is required" || return 1
+	[[ "$(jq -r '.version // empty' CloudronManifest.json)" == "$expected_version" ]] || fail "CloudronManifest.json version does not match ${expected_version}" || return 1
+	if jq -e --arg version "$expected_version" '.versions[$version] != null' "$catalog_path" >/dev/null; then
+		fail "Catalog already contains version ${expected_version}" || return 1
+	fi
+
+	cloudron versions add --state testing --image "$image_ref"
+	generated_key="$(resolve_version_key "$catalog_path" "$expected_version" "$image_ref")" || return 1
+	verify_entry "$catalog_path" "$generated_key" testing "$image_ref" || return 1
+	cloudron versions update --version="$generated_key" --state=published --image "$image_ref"
+	verify_entry "$catalog_path" "$generated_key" published "$image_ref" || return 1
+	cloudron versions verify
+	return 0
+}
+
+main "$@"

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -21,7 +21,7 @@ assert_contains() {
 }
 
 main() {
-	jq -e '.manifestVersion == 2 and .version == "2.0.4" and .upstreamVersion == "0.75.0" and .minBoxVersion == "9.1.0" and .iconUrl != "" and .packagerName != "" and .packagerUrl == "https://github.com/marcusquinn" and (has("packageUrl") | not) and (.mediaLinks | length) > 0 and .changelog == "file://CHANGELOG"' \
+	jq -e '.manifestVersion == 2 and .version == "2.0.5" and .upstreamVersion == "0.75.0" and .minBoxVersion == "9.1.0" and .iconUrl != "" and .packagerName != "" and .packagerUrl == "https://github.com/marcusquinn" and (has("packageUrl") | not) and (.mediaLinks | length) > 0 and .changelog == "file://CHANGELOG"' \
 		"${ROOT_DIR}/CloudronManifest.json" >/dev/null || fail "Manifest version contract failed" || return 1
 	[[ -f "${ROOT_DIR}/CloudronVersions.json" ]] || fail "CloudronVersions.json is missing" || return 1
 	[[ -f "${ROOT_DIR}/PUBLISHING.md" ]] || fail "PUBLISHING.md is missing" || return 1
@@ -29,19 +29,21 @@ main() {
 	[[ -f "${ROOT_DIR}/media/hero.png" ]] || fail "media/hero.png is missing" || return 1
 	jq -e '.stable == true and (.versions | type == "object")' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Version catalog contract failed" || return 1
 	jq -e '[.versions[].manifest | has("packageUrl")] | all(. == false)' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Historical catalog entries must not use Cloudron-10-only packageUrl" || return 1
-	assert_contains CHANGELOG '[2.0.4]' || return 1
-	assert_contains CHANGELOG.md '[2.0.4]' || return 1
-	assert_contains PUBLISHING.md 'cloudron versions update --version=<VERSION> --state=published' || return 1
+	assert_contains CHANGELOG '[2.0.5]' || return 1
+	assert_contains CHANGELOG.md '[2.0.5] - 2026-07-30' || return 1
+	assert_contains PUBLISHING.md 'is standing authorization for the managed publication' || return 1
+	assert_contains PUBLISHING.md 'ghcr.io/marcusquinn/cloudron-netbird-app' || return 1
 	jq -e '.versions["2.0.3"].publishState == "published"' "${ROOT_DIR}/CloudronVersions.json" >/dev/null || fail "Published catalog state contract failed" || return 1
 	assert_contains Dockerfile 'netbirdio/netbird-server:0.75.0@sha256:9f8dbb2fee412f91acee1a280c6c06fe8a7bea7b615c37530d6a7bba2edcf901 AS server' || return 1
 	assert_contains Dockerfile 'netbirdio/dashboard:v2.90.7@sha256:4b9d5eedede5b55737546124162f15ba0c79a32e78ba4c3218549be96ad22fb1 AS dashboard' || return 1
 	assert_contains Dockerfile 'cloudron/base:5.0.0@sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c' || return 1
+	assert_contains Dockerfile 'LABEL org.opencontainers.image.source="https://github.com/marcusquinn/cloudron-netbird-app"' || return 1
 	assert_contains start.sh 'DASHBOARD_DIR="/app/data/dashboard"' || return 1
 	assert_contains start.sh 'root /app/data/dashboard;' || return 1
 	assert_contains start.sh 'error_log /run/nginx/error.log;' || return 1
 	assert_contains start.sh 'listen 8080;' || return 1
 	assert_contains start.sh 'openssl rand -base64 32' || return 1
-	assert_contains PUBLISHING.md 'DOCKER_DEFAULT_PLATFORM=linux/amd64' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml 'platforms: linux/amd64' || return 1
 	assert_contains Dockerfile 'COPY --from=server /go/bin/netbird-server /app/code/bin/netbird-server' || return 1
 	assert_contains Dockerfile 'COPY --from=dashboard /usr/share/nginx/html/ /app/code/dashboard/' || return 1
 	if grep -Eq '/releases/latest([/?#]|$)' "${ROOT_DIR}/Dockerfile"; then
@@ -50,8 +52,25 @@ main() {
 	assert_contains .github/workflows/cloudron-package-release.yml "- 'v*'" || return 1
 	assert_contains .github/workflows/cloudron-package-release.yml 'uses: marcusquinn/aidevops/.github/workflows/cloudron-package-release-reusable.yml@22a6b4b29087ce2fcf3857596a40ff7b2c436482' || return 1
 	assert_contains .github/workflows/cloudron-package-release.yml 'aidevops_ref: 22a6b4b29087ce2fcf3857596a40ff7b2c436482' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml 'IMAGE_REPOSITORY: ghcr.io/marcusquinn/cloudron-netbird-app' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml 'pull_request:' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml "github.event_name != 'pull_request'" || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml 'scripts/publish-cloudron-catalog.sh' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml ".versions[\$version].manifest.dockerImage" || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml 'persist-credentials: false' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml 'Verify the build source stayed immutable' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml 'Verify anonymous registry visibility' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml "docker buildx imagetools inspect \"\${EXPECTED_IMAGE_REF}\"" || return 1
+	if grep -Fq 'include-hidden-files: true' "${ROOT_DIR}/.github/workflows/cloudron-catalog-publish.yml"; then
+		fail "Release workflow uploads hidden checkout credentials" || return 1
+	fi
+	assert_contains .github/workflows/cloudron-catalog-publish.yml "git diff --exit-code \"\${before_sha}\" -- CloudronManifest.json CHANGELOG CHANGELOG.md" || return 1
+	if grep -Fq -- '--versions-file' "${ROOT_DIR}/scripts/publish-cloudron-catalog.sh"; then
+		fail "Publisher uses unsupported Cloudron CLI --versions-file option" || return 1
+	fi
+	bash "${ROOT_DIR}/test/publish-catalog-test.sh" || return 1
 	bash -n "${ROOT_DIR}/start.sh"
-	shellcheck "${ROOT_DIR}/test/package-test.sh"
+	shellcheck "${ROOT_DIR}/test/package-test.sh" "${ROOT_DIR}/test/publish-catalog-test.sh" "${ROOT_DIR}/scripts/publish-cloudron-catalog.sh"
 	printf 'PASS: deterministic Cloudron package and publishing lifecycle contract\n'
 	return 0
 }

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -55,11 +55,15 @@ main() {
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'IMAGE_REPOSITORY: ghcr.io/marcusquinn/cloudron-netbird-app' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'pull_request:' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml "github.event_name != 'pull_request'" || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml 'Require trusted publication source' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml 'EXPECTED_REF: refs/heads/main' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'scripts/publish-cloudron-catalog.sh' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml ".versions[\$version].manifest.dockerImage" || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'persist-credentials: false' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'Verify the build source stayed immutable' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'Verify anonymous registry visibility' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml 'Verify existing immutable image is anonymously pullable' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml "docker buildx imagetools inspect \"\${IMMUTABLE_REF}\"" || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml "docker buildx imagetools inspect \"\${EXPECTED_IMAGE_REF}\"" || return 1
 	if grep -Fq 'include-hidden-files: true' "${ROOT_DIR}/.github/workflows/cloudron-catalog-publish.yml"; then
 		fail "Release workflow uploads hidden checkout credentials" || return 1

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -59,6 +59,12 @@ main() {
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'EXPECTED_REF: refs/heads/main' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'scripts/publish-cloudron-catalog.sh' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml ".versions[\$version].manifest.dockerImage" || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml "git push --atomic origin HEAD:main \"v\${RELEASE_VERSION}\"" || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml 'Reconcile GitHub release' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml "git show \"v\${RELEASE_VERSION}:CloudronVersions.json\"" || return 1
+	if grep -Fq 'git push origin HEAD:main' "${ROOT_DIR}/.github/workflows/cloudron-catalog-publish.yml"; then
+		fail "Release workflow publishes the catalog and tag non-atomically" || return 1
+	fi
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'persist-credentials: false' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'Verify the build source stayed immutable' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'Verify anonymous registry visibility' || return 1

--- a/test/publish-catalog-test.sh
+++ b/test/publish-catalog-test.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+ROOT_DIR="${TEST_DIR%/*}"
+TMP_ROOT=""
+
+cleanup() {
+	local status="$?"
+	if [[ -n "$TMP_ROOT" && -d "$TMP_ROOT" ]]; then
+		rm -rf "$TMP_ROOT"
+	fi
+	return "$status"
+}
+
+trap cleanup EXIT
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+make_fixture() {
+	local fixture_name="$1"
+	local fixture_dir="${TMP_ROOT}/${fixture_name}"
+	local initial_version="${2:-2.0.4}"
+
+	mkdir -p "${fixture_dir}/bin"
+	cp "${ROOT_DIR}/scripts/publish-cloudron-catalog.sh" "${fixture_dir}/publish-cloudron-catalog.sh"
+	cat >"${fixture_dir}/CloudronManifest.json" <<JSON
+{"version":"2.0.5","upstreamVersion":"0.75.0","manifestVersion":2}
+JSON
+	cat >"${fixture_dir}/CloudronVersions.json" <<JSON
+{"stable":true,"versions":{"${initial_version}":{"manifest":{"version":"${initial_version}","dockerImage":"registry.example/netbird@sha256:old"},"publishState":"published"}}}
+JSON
+	cat >"${fixture_dir}/bin/cloudron" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ "${1:-}" == "versions" ]] || exit 2
+subcommand="${2:-}"
+shift 2
+catalog="CloudronVersions.json"
+image=""
+version=""
+state=""
+
+for argument in "$@"; do
+	case "$argument" in
+		--image=*) image="${argument#*=}" ;;
+		--image) ;;
+		--version=*) version="${argument#*=}" ;;
+		--state=*) state="${argument#*=}" ;;
+		testing|published) state="$argument" ;;
+		*)
+			if [[ -z "$catalog" && "$argument" == *.json ]]; then
+				catalog="$argument"
+			elif [[ -z "$image" && "$argument" == *@sha256:* ]]; then
+				image="$argument"
+			fi
+			;;
+	esac
+done
+
+case "$subcommand" in
+	add)
+		manifest_version="$(jq -r '.version' CloudronManifest.json)"
+		generated_key="${FAKE_GENERATED_KEY:-$manifest_version}"
+		generated_manifest_version="${FAKE_MANIFEST_VERSION:-$manifest_version}"
+		if [[ "$generated_manifest_version" == "__missing__" ]]; then
+			generated_manifest="$(jq -cn --arg image "$image" '{dockerImage:$image}')"
+		else
+			generated_manifest="$(jq -cn --arg version "$generated_manifest_version" --arg image "$image" '{version:$version,dockerImage:$image}')"
+		fi
+		jq \
+			--arg key "$generated_key" \
+			--arg image "$image" \
+			--arg state "${state:-testing}" \
+			--argjson manifest "$generated_manifest" \
+			'.versions[$key] = {manifest:$manifest,publishState:$state}' \
+			"$catalog" >"${catalog}.tmp"
+		if [[ -n "${FAKE_SECOND_GENERATED_KEY:-}" ]]; then
+			jq \
+				--arg key "$FAKE_SECOND_GENERATED_KEY" \
+				--arg image "$image" \
+				--arg state "${state:-testing}" \
+				--argjson manifest "$generated_manifest" \
+				'.versions[$key] = {manifest:$manifest,publishState:$state}' \
+				"${catalog}.tmp" >"${catalog}.second"
+			mv "${catalog}.second" "${catalog}.tmp"
+		fi
+		mv "${catalog}.tmp" "$catalog"
+		;;
+	update)
+		if [[ -z "$image" ]]; then
+			printf 'missing immutable image during update\n' >&2
+			exit 8
+		fi
+		if [[ -n "${FAKE_EXPECT_UPDATE_VERSION:-}" && "$version" != "$FAKE_EXPECT_UPDATE_VERSION" ]]; then
+			printf 'wrong update target: %s\n' "$version" >&2
+			exit 9
+		fi
+		jq --arg version "$version" --arg state "$state" --arg image "$image" '.versions[$version].publishState = $state | .versions[$version].manifest.dockerImage = $image' "$catalog" >"${catalog}.tmp"
+		mv "${catalog}.tmp" "$catalog"
+		;;
+	verify)
+		jq -e '.stable == true and (.versions | type == "object")' "$catalog" >/dev/null
+		;;
+	*) exit 3 ;;
+esac
+STUB
+	chmod +x "${fixture_dir}/bin/cloudron" "${fixture_dir}/publish-cloudron-catalog.sh"
+	printf '%s\n' "$fixture_dir"
+	return 0
+}
+
+assert_successful_publish() {
+	local fixture_dir=""
+	local image_ref="registry.example/netbird@sha256:0123456789abcdef"
+	fixture_dir="$(make_fixture success)" || return 1
+
+	(
+		cd "$fixture_dir" || exit 1
+		PATH="${fixture_dir}/bin:${PATH}" \
+			./publish-cloudron-catalog.sh CloudronVersions.json "$image_ref" 2.0.5
+	)
+
+	jq -e --arg image "$image_ref" \
+		'.versions["2.0.5"].manifest.version == "2.0.5" and .versions["2.0.5"].manifest.dockerImage == $image and .versions["2.0.5"].publishState == "published"' \
+		"${fixture_dir}/CloudronVersions.json" >/dev/null || fail "Successful publish did not create the verified published entry" || return 1
+	return 0
+}
+
+assert_wrong_generated_key_fails() {
+	local fixture_dir=""
+	local output_file=""
+	fixture_dir="$(make_fixture wrong-key)" || return 1
+	output_file="${fixture_dir}/output.log"
+
+	if (
+		cd "$fixture_dir" || exit 1
+		PATH="${fixture_dir}/bin:${PATH}" \
+			FAKE_GENERATED_KEY="2.0.50" \
+			./publish-cloudron-catalog.sh CloudronVersions.json registry.example/netbird@sha256:wrong 2.0.5
+	) >"$output_file" 2>&1; then
+		fail "Publisher accepted a generated key that differed from the manifest version" || return 1
+	fi
+	grep -Fq 'does not match expected version 2.0.5' "$output_file" || fail "Wrong-key failure did not explain the mismatch" || return 1
+	return 0
+}
+
+assert_missing_manifest_version_fails() {
+	local fixture_dir=""
+	local output_file=""
+	fixture_dir="$(make_fixture missing-manifest-version)" || return 1
+	output_file="${fixture_dir}/output.log"
+
+	if (
+		cd "$fixture_dir" || exit 1
+		PATH="${fixture_dir}/bin:${PATH}" \
+			FAKE_MANIFEST_VERSION="__missing__" \
+			./publish-cloudron-catalog.sh CloudronVersions.json registry.example/netbird@sha256:missing 2.0.5
+	) >"$output_file" 2>&1; then
+		fail "Publisher accepted an entry without manifest.version" || return 1
+	fi
+	grep -Fq 'Generated manifest version <missing> does not match 2.0.5' "$output_file" || fail "Missing manifest-version failure was not diagnostic" || return 1
+	return 0
+}
+
+assert_no_generated_entry_fails() {
+	local fixture_dir=""
+	local output_file=""
+	fixture_dir="$(make_fixture no-entry)" || return 1
+	output_file="${fixture_dir}/output.log"
+
+	if (
+		cd "$fixture_dir" || exit 1
+		PATH="${fixture_dir}/bin:${PATH}" \
+			FAKE_GENERATED_KEY="2.0.50" \
+			FAKE_MANIFEST_VERSION="2.0.50" \
+			./publish-cloudron-catalog.sh CloudronVersions.json registry.example/netbird@sha256:no-entry 2.0.5
+	) >"$output_file" 2>&1; then
+		fail "Publisher accepted a catalog without the expected key" || return 1
+	fi
+	grep -Fq 'does not match expected version 2.0.5' "$output_file" || fail "Missing-entry failure was not diagnostic" || return 1
+	return 0
+}
+
+assert_multiple_generated_entries_fail() {
+	local fixture_dir=""
+	local output_file=""
+	fixture_dir="$(make_fixture multiple-entries)" || return 1
+	output_file="${fixture_dir}/output.log"
+
+	if (
+		cd "$fixture_dir" || exit 1
+		PATH="${fixture_dir}/bin:${PATH}" \
+			FAKE_SECOND_GENERATED_KEY="2.0.50" \
+			./publish-cloudron-catalog.sh CloudronVersions.json registry.example/netbird@sha256:multiple 2.0.5
+	) >"$output_file" 2>&1; then
+		fail "Publisher accepted multiple generated entries for one image" || return 1
+	fi
+	grep -Fq 'Expected exactly one generated catalog entry' "$output_file" || fail "Multiple-entry failure was not diagnostic" || return 1
+	return 0
+}
+
+assert_update_targets_expected_version() {
+	local fixture_dir=""
+	fixture_dir="$(make_fixture update-target)" || return 1
+
+	(
+		cd "$fixture_dir" || exit 1
+		PATH="${fixture_dir}/bin:${PATH}" \
+			FAKE_EXPECT_UPDATE_VERSION="2.0.5" \
+			./publish-cloudron-catalog.sh CloudronVersions.json registry.example/netbird@sha256:update-target 2.0.5
+	) || fail "Publisher did not promote the expected manifest version" || return 1
+	return 0
+}
+
+assert_mutable_image_fails() {
+	local fixture_dir=""
+	local output_file=""
+	fixture_dir="$(make_fixture mutable-image)" || return 1
+	output_file="${fixture_dir}/output.log"
+
+	if (
+		cd "$fixture_dir" || exit 1
+		PATH="${fixture_dir}/bin:${PATH}" \
+			./publish-cloudron-catalog.sh CloudronVersions.json registry.example/netbird:2.0.5 2.0.5
+	) >"$output_file" 2>&1; then
+		fail "Publisher accepted a mutable image tag" || return 1
+	fi
+	grep -Fq 'Image reference must use an immutable sha256 digest' "$output_file" || fail "Mutable-image failure was not diagnostic" || return 1
+	return 0
+}
+
+assert_duplicate_version_fails() {
+	local fixture_dir=""
+	local output_file=""
+	fixture_dir="$(make_fixture duplicate-version 2.0.5)" || return 1
+	output_file="${fixture_dir}/output.log"
+
+	if (
+		cd "$fixture_dir" || exit 1
+		PATH="${fixture_dir}/bin:${PATH}" \
+			./publish-cloudron-catalog.sh CloudronVersions.json registry.example/netbird@sha256:duplicate 2.0.5
+	) >"$output_file" 2>&1; then
+		fail "Publisher accepted a duplicate catalog version" || return 1
+	fi
+	grep -Fq 'Catalog already contains version 2.0.5' "$output_file" || fail "Duplicate-version failure was not diagnostic" || return 1
+	return 0
+}
+
+assert_non_default_catalog_fails() {
+	local fixture_dir=""
+	local output_file=""
+	fixture_dir="$(make_fixture non-default-catalog)" || return 1
+	output_file="${fixture_dir}/output.log"
+	cp "${fixture_dir}/CloudronVersions.json" "${fixture_dir}/AlternateVersions.json"
+
+	if (
+		cd "$fixture_dir" || exit 1
+		PATH="${fixture_dir}/bin:${PATH}" \
+			./publish-cloudron-catalog.sh AlternateVersions.json registry.example/netbird@sha256:alternate 2.0.5
+	) >"$output_file" 2>&1; then
+		fail "Publisher accepted a catalog filename unsupported by Cloudron CLI 8.2.6" || return 1
+	fi
+	grep -Fq 'requires the catalog path CloudronVersions.json' "$output_file" || fail "Unsupported catalog-path failure was not diagnostic" || return 1
+	return 0
+}
+
+main() {
+	local temp_base="${AIDEVOPS_TEMP_DIR:-${TMPDIR:-/tmp}}"
+	mkdir -p "$temp_base"
+	TMP_ROOT="$(mktemp -d "${temp_base%/}/cloudron-catalog-test.XXXXXX")"
+	assert_successful_publish || return 1
+	assert_wrong_generated_key_fails || return 1
+	assert_missing_manifest_version_fails || return 1
+	assert_no_generated_entry_fails || return 1
+	assert_multiple_generated_entries_fail || return 1
+	assert_update_targets_expected_version || return 1
+	assert_mutable_image_fails || return 1
+	assert_duplicate_version_fails || return 1
+	assert_non_default_catalog_fails || return 1
+	printf 'PASS: fail-closed Cloudron catalog publisher contract\n'
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add fail-closed merge-triggered image, catalog, tag, and GitHub release publication, and prepare NetBird package 2.0.5.

## Files Changed

.github/workflows/cloudron-catalog-publish.yml, CHANGELOG, CHANGELOG.md, CloudronManifest.json, Dockerfile, PUBLISHING.md, TODO.md, scripts/publish-cloudron-catalog.sh, test/package-test.sh, test/publish-catalog-test.sh

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: docker buildx built the linux/amd64 image; a fresh container verified Nginx 1.24.0, Supervisord 4.2.5, the NetBird binary, dashboard, start script, and public-repository OCI label. Package tests, ShellCheck, actionlint, real Cloudron CLI add/promote/verify simulation, catalog verification, and manifest-format 6.2.0 also passed.

Resolves #64


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 3h 52m and 1,742,894 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Cloudron release publishing after approved package updates.
  * Releases now build and publish immutable AMD64 images, verify catalog entries, and create corresponding tags and releases.
  * Added fail-closed validation for image digests, catalog versions, and publication status.
  * Updated the application version to 2.0.5.

* **Documentation**
  * Updated publishing guidance and changelogs for the automated release process.

* **Tests**
  * Added comprehensive validation for catalog publishing and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->