### PR TITLE
t021: fix: grant release attestation permission

### DIFF
--- a/.github/workflows/cloudron-catalog-publish.yml
+++ b/.github/workflows/cloudron-catalog-publish.yml
@@ -89,6 +89,7 @@ jobs:
     if: github.event_name != 'pull_request' && needs.preflight.outputs.publish == 'true'
     runs-on: ubuntu-24.04
     permissions:
+      attestations: write
       contents: read
       packages: write
       id-token: write

--- a/TODO.md
+++ b/TODO.md
@@ -71,6 +71,8 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 
 - [ ] t020 Automate Cloudron releases after package updates merge #feat #priority:high ref:GH#64
 
+- [ ] t021 Restore release publication after attestation permission failure #bug #priority:high ref:GH#66
+
 ## In Progress
 
 <!--TOON:in_progress[0]{id,desc,owner,tags,est,risk,logged,started,status}:

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -57,6 +57,7 @@ main() {
 	assert_contains .github/workflows/cloudron-catalog-publish.yml "github.event_name != 'pull_request'" || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'Require trusted publication source' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'EXPECTED_REF: refs/heads/main' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml 'attestations: write' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'scripts/publish-cloudron-catalog.sh' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml ".versions[\$version].manifest.dockerImage" || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml "git push --atomic origin HEAD:main \"v\${RELEASE_VERSION}\"" || return 1


### PR DESCRIPTION
## Summary

Implementation for issue #66.

## Files Changed

.github/workflows/cloudron-catalog-publish.yml, TODO.md, test/package-test.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — no additional evidence supplied

Resolves #66


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 4h 29m and 2,189,615 tokens on this with the user in an interactive session.