### PR TITLE
fix: authenticate Cloudron catalog publication

### DIFF
--- a/.github/workflows/cloudron-catalog-publish.yml
+++ b/.github/workflows/cloudron-catalog-publish.yml
@@ -154,6 +154,7 @@ jobs:
         with:
           ref: ${{ needs.preflight.outputs.before_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Verify the release source stayed immutable
         run: test "$(git rev-parse HEAD)" = "${{ needs.preflight.outputs.before_sha }}"
@@ -189,8 +190,13 @@ jobs:
 
       - name: Commit generated catalog
         env:
+          GH_TOKEN: ${{ secrets.CLOUDRON_RELEASE_PAT }}
           RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
         run: |
+          if [[ -z "${GH_TOKEN}" ]]; then
+            printf 'CLOUDRON_RELEASE_PAT is not configured for this repository\n' >&2
+            exit 1
+          fi
           before_sha="${{ needs.preflight.outputs.before_sha }}"
           git diff --exit-code "${before_sha}" -- CloudronManifest.json CHANGELOG CHANGELOG.md
           git add CloudronVersions.json
@@ -198,8 +204,10 @@ jobs:
           test "$(git diff --cached --name-only)" = "CloudronVersions.json"
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git commit -m "chore: publish Cloudron package ${RELEASE_VERSION}"
+          git commit -m "chore: publish Cloudron package ${RELEASE_VERSION} [skip ci]"
           git tag -a "v${RELEASE_VERSION}" -m "Release v${RELEASE_VERSION}"
+          # aidevops:trust-boundary — expose the repository-scoped admin credential only after validation.
+          gh auth setup-git
           git push --atomic origin HEAD:main "v${RELEASE_VERSION}"
 
       - name: Create GitHub release

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -36,6 +36,22 @@ tag or digest into the catalog.
 The workflow is the only supported catalog writer. A merge that does not bump
 `CloudronManifest.json` is a verified no-op and does not create another release.
 
+## Release credential
+
+The protected `main` branch requires the repository secret
+`CLOUDRON_RELEASE_PAT`. Use a separate fine-grained PAT for this repository,
+owned by a repository administrator and limited to this repository with only
+`Contents: Read and write`. Do not grant workflow permissions or reuse the
+credential in another repository. The workflow exposes it only to the final
+validated catalog commit and atomic tag push; GHCR, attestations, and GitHub
+release operations continue to use `GITHUB_TOKEN`. The generated catalog commit
+includes `[skip ci]` so its PAT-authenticated branch and tag push cannot launch
+duplicate publication workflows.
+
+If the PAT is absent, expired, or revoked, publication fails before the push
+without changing the catalog or tag. Rotate the repository secret and rerun the
+workflow from `main`.
+
 Published entries are append-only. For a critical bad release, run
 `cloudron versions revoke`, bump the package version, rebuild, and add a new
 entry. Do not mutate the manifest or image of a published version.

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -81,6 +81,12 @@ main() {
 		fail "Release workflow publishes the catalog and tag non-atomically" || return 1
 	fi
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'persist-credentials: false' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml "GH_TOKEN: \${{ secrets.CLOUDRON_RELEASE_PAT }}" || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml 'CLOUDRON_RELEASE_PAT is not configured for this repository' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml 'gh auth setup-git' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml "chore: publish Cloudron package \${RELEASE_VERSION} [skip ci]" || return 1
+	assert_precedes .github/workflows/cloudron-catalog-publish.yml 'git diff --exit-code' 'gh auth setup-git' || return 1
+	assert_precedes .github/workflows/cloudron-catalog-publish.yml 'gh auth setup-git' 'git push --atomic' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'Verify the build source stayed immutable' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'Verify anonymous registry visibility' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'Verify existing immutable image is anonymously pullable' || return 1
@@ -89,6 +95,7 @@ main() {
 	if grep -Fq 'include-hidden-files: true' "${ROOT_DIR}/.github/workflows/cloudron-catalog-publish.yml"; then
 		fail "Release workflow uploads hidden checkout credentials" || return 1
 	fi
+	[[ "$(grep -Fc 'secrets.CLOUDRON_RELEASE_PAT' "${ROOT_DIR}/.github/workflows/cloudron-catalog-publish.yml")" -eq 1 ]] || fail "Release PAT must be exposed to exactly one publication step" || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml "git diff --exit-code \"\${before_sha}\" -- CloudronManifest.json CHANGELOG CHANGELOG.md" || return 1
 	if grep -Fq -- '--versions-file' "${ROOT_DIR}/scripts/publish-cloudron-catalog.sh"; then
 		fail "Publisher uses unsupported Cloudron CLI --versions-file option" || return 1


### PR DESCRIPTION
## Goal

Allow the validated Cloudron catalog commit and package tag to be published to protected `main` using the established personal-repository credential pattern.

## Changes

- use the per-repository `CLOUDRON_RELEASE_PAT` only in the final catalog commit step
- disable persisted checkout credentials and configure Git authentication immediately before the atomic push
- fail closed when the release credential is absent
- mark the generated catalog commit `[skip ci]` to prevent PAT-authenticated workflow recursion
- document least-privilege scope, rollback, and recovery
- add regression checks for credential isolation and operation ordering

## Security

The fine-grained PAT must be owned by a repository administrator, selected for this repository only, and grant only `Contents: Read and write`. GHCR, attestations, and GitHub release creation continue to use `GITHUB_TOKEN`. No credential value is committed or logged.

## Verification

- `bash test/package-test.sh`
- `actionlint .github/workflows/cloudron-catalog-publish.yml`
- `git diff --check`

## Rollout

Configure the `CLOUDRON_RELEASE_PAT` repository secret before merge. After merge, dispatch `Publish Cloudron Catalog` from `main` and verify the catalog commit, `v2.0.5` tag, image digest, attestation, and GitHub release.

For #66

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198 plugin for [OpenCode](https://opencode.ai) v1.18.10 with gpt-5.6-sol spent 5h 24m and 2,828,636 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release publishing authentication and credential handling.
  * Added safeguards to prevent unintended workflow reruns during automated commits.
  * Publishing now fails clearly when required release credentials are unavailable.

* **Documentation**
  * Documented release credential requirements, permitted usage, ownership, and rotation procedures.

* **Tests**
  * Expanded package validation to cover authentication, commit messaging, and publication order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->