### PR TITLE
t022: Add keyless provenance for Cloudron catalogs

### DIFF
--- a/.github/workflows/cloudron-catalog-publish.yml
+++ b/.github/workflows/cloudron-catalog-publish.yml
@@ -147,7 +147,9 @@ jobs:
     if: github.event_name != 'pull_request' && needs.preflight.outputs.publish == 'true'
     runs-on: ubuntu-24.04
     permissions:
+      attestations: write
       contents: write
+      id-token: write
     steps:
       - name: Check out the verified revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -187,6 +189,22 @@ jobs:
           EXPECTED_IMAGE_REF: ${{ needs.build.outputs.image_ref }}
           EXPECTED_VERSION: ${{ needs.preflight.outputs.version }}
         run: bash scripts/publish-cloudron-catalog.sh CloudronVersions.json "${EXPECTED_IMAGE_REF}" "${EXPECTED_VERSION}"
+
+      - name: Attest catalog provenance
+        id: attest-catalog
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: CloudronVersions.json
+
+      - name: Verify catalog provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh attestation verify CloudronVersions.json \
+            --bundle "${{ steps.attest-catalog.outputs.bundle-path }}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/cloudron-catalog-publish.yml" \
+            --source-ref refs/heads/main
 
       - name: Commit generated catalog
         env:
@@ -246,7 +264,9 @@ jobs:
     if: github.event_name != 'pull_request' && needs.preflight.outputs.publish == 'false'
     runs-on: ubuntu-24.04
     permissions:
+      attestations: write
       contents: write
+      id-token: write
     steps:
       - name: Check out published source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -266,6 +286,22 @@ jobs:
               jq -r --arg version "${RELEASE_VERSION}" '.versions[$version].manifest.dockerImage'
           )"
           test "${tagged_image_ref}" = "${IMMUTABLE_REF}"
+
+      - name: Attest existing catalog provenance
+        id: attest-catalog
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: CloudronVersions.json
+
+      - name: Verify existing catalog provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh attestation verify CloudronVersions.json \
+            --bundle "${{ steps.attest-catalog.outputs.bundle-path }}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/cloudron-catalog-publish.yml" \
+            --source-ref refs/heads/main
 
       - name: Reconcile GitHub release
         env:

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -20,21 +20,29 @@ tag or digest into the catalog.
 4. The workflow runs `scripts/publish-cloudron-catalog.sh`, which adds the new
    manifest version in testing state, verifies the generated entry and digest,
    promotes that exact version to published, and verifies the final catalog.
-5. The workflow commits only the generated `CloudronVersions.json`, atomically
-   pushes that commit with the matching `v<VERSION>` tag, attests the image
-   digest, and creates the GitHub release, but only after an anonymous pull
-   probe resolves that exact digest. Existing published versions reverify the
-   anonymous image and tagged catalog digest, then reconcile a missing GitHub
-   release. Mutable, unpublished, or conflicting entries fail closed.
-6. For release qualification, test a clean install with
+5. GitHub Actions uses OIDC and Sigstore keyless signing to attest both the
+   immutable image digest and the exact generated `CloudronVersions.json`. The
+   workflow verifies the catalog attestation bundle against this repository,
+   the catalog publication workflow, and `refs/heads/main` before committing.
+6. The workflow commits only the generated `CloudronVersions.json`, atomically
+   pushes that commit with the matching `v<VERSION>` tag, and creates the GitHub
+   release, but only after an anonymous pull probe resolves that exact digest.
+   Existing published versions reverify the anonymous image and tagged catalog
+   digest, attest and verify the current catalog without a version bump, then
+   reconcile a missing GitHub release. Mutable, unpublished, or conflicting
+   entries fail closed.
+7. For release qualification, test a clean install with
    `cloudron install --versions-url <PUBLIC_VERSIONS_URL> --location netbird-test`.
    Also verify upgrade, restart, health checks, and backup/restore.
-7. Optionally sign in to [Cloudron Community Apps](https://ca.cloudron.io), add
+8. Optionally sign in to [Cloudron Community Apps](https://ca.cloudron.io), add
    the same versions URL, and verify the imported icon, screenshot/hero,
    description, changelog, and install URL.
 
 The workflow is the only supported catalog writer. A merge that does not bump
 `CloudronManifest.json` is a verified no-op and does not create another release.
+Cloudron does not currently enforce this keyless provenance; the attestations
+provide independently verifiable supply-chain evidence for operators and
+future policy enforcement.
 
 ## Release credential
 

--- a/TODO.md
+++ b/TODO.md
@@ -73,6 +73,8 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 
 - [ ] t021 Restore release publication after attestation permission failure #bug #priority:high ref:GH#66
 
+- [ ] t022 Add keyless provenance for Cloudron catalogs ref:GH#74
+
 ## In Progress
 
 <!--TOON:in_progress[0]{id,desc,owner,tags,est,risk,logged,started,status}:

--- a/test/package-test.sh
+++ b/test/package-test.sh
@@ -72,6 +72,14 @@ main() {
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'Require trusted publication source' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'EXPECTED_REF: refs/heads/main' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'attestations: write' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml 'subject-path: CloudronVersions.json' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml 'gh attestation verify CloudronVersions.json' || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml "--bundle \"\${{ steps.attest-catalog.outputs.bundle-path }}\"" || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml "--signer-workflow \"\${GITHUB_REPOSITORY}/.github/workflows/cloudron-catalog-publish.yml\"" || return 1
+	assert_contains .github/workflows/cloudron-catalog-publish.yml '--source-ref refs/heads/main' || return 1
+	[[ "$(grep -Fc 'subject-path: CloudronVersions.json' "${ROOT_DIR}/.github/workflows/cloudron-catalog-publish.yml")" -eq 2 ]] || fail "Both catalog publication paths must attest CloudronVersions.json" || return 1
+	[[ "$(grep -Fc 'gh attestation verify CloudronVersions.json' "${ROOT_DIR}/.github/workflows/cloudron-catalog-publish.yml")" -eq 2 ]] || fail "Both catalog publication paths must verify catalog provenance" || return 1
+	[[ "$(grep -Fc -- '--source-ref refs/heads/main' "${ROOT_DIR}/.github/workflows/cloudron-catalog-publish.yml")" -eq 2 ]] || fail "Both catalog provenance checks must require main as the source ref" || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'scripts/publish-cloudron-catalog.sh' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml ".versions[\$version].manifest.dockerImage" || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml "git push --atomic origin HEAD:main \"v\${RELEASE_VERSION}\"" || return 1
@@ -87,6 +95,8 @@ main() {
 	assert_contains .github/workflows/cloudron-catalog-publish.yml "chore: publish Cloudron package \${RELEASE_VERSION} [skip ci]" || return 1
 	assert_precedes .github/workflows/cloudron-catalog-publish.yml 'git diff --exit-code' 'gh auth setup-git' || return 1
 	assert_precedes .github/workflows/cloudron-catalog-publish.yml 'gh auth setup-git' 'git push --atomic' || return 1
+	assert_precedes .github/workflows/cloudron-catalog-publish.yml 'Publish and verify catalog entry' 'Attest catalog provenance' || return 1
+	assert_precedes .github/workflows/cloudron-catalog-publish.yml 'Verify catalog provenance' 'Commit generated catalog' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'Verify the build source stayed immutable' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'Verify anonymous registry visibility' || return 1
 	assert_contains .github/workflows/cloudron-catalog-publish.yml 'Verify existing immutable image is anonymously pullable' || return 1


### PR DESCRIPTION
## Summary

Attest generated and existing Cloudron catalog bytes with GitHub OIDC/Sigstore and verify the exact bundle before publication.

## Files Changed

.github/workflows/cloudron-catalog-publish.yml, PUBLISHING.md, TODO.md, test/package-test.sh

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Package publisher tests and actionlint pass locally; post-merge catalog workflow and public attestation verification will provide runtime evidence.

Resolves #74


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.206 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 1h 32m and 387,503 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Release catalogs now include verifiable, keyless provenance attestations.
  - Catalog provenance is validated before publication, helping confirm that releases were generated through the official process.
  - Existing releases can be re-attested and verified without changing their versions.

- **Documentation**
  - Updated release guidance explains catalog verification, publication safeguards, and provenance evidence.
  - Added a follow-up task for strengthening catalog provenance enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->