### PR TITLE
GH#85: Address NetBird package review findings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,7 @@ EXPOSE 8080
 # Expose STUN UDP port
 EXPOSE 3478/udp
 
+# The Cloudron base image provides this unprivileged runtime user.
+USER cloudron
+
 CMD ["/app/code/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,4 @@ EXPOSE 8080
 # Expose STUN UDP port
 EXPOSE 3478/udp
 
-# The Cloudron base image provides this unprivileged runtime user.
-USER cloudron
-
 CMD ["/app/code/start.sh"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | App Version | Upstream NetBird | Supported |
 |-------------|------------------|-----------:|
-| 2.0.0       | 0.65.3           | Yes        |
-| < 2.0.0     | N/A              | No         |
+| 2.0.9       | 0.76.3           | Yes        |
+| < 2.0.9     | N/A              | No         |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Resolves #85

## Summary

- align the supported-version matrix with package `2.0.9` and NetBird `0.76.3`
- retain root only for the entrypoint's required runtime-directory initialization;
  supervisord already launches nginx and netbird-server as `cloudron`

## Verification

- `git diff --check`
- `docker build --tag netbird-issue-85:local .`
- `bash test/package-test.sh`
- `bash test/publish-catalog-test.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.243 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the supported application version to 2.0.9.
  * Updated the corresponding upstream version to 0.76.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->